### PR TITLE
Fix stalled local AssemblyAI uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,11 @@ PIXABAY_API_KEY=
 UNSPLASH_ACCESS_KEY=
 FREESOUND_API_KEY=
 
+# AssemblyAI transcription. This key stays server-side: local uploaded media is
+# streamed directly from the OpenChatCut server to AssemblyAI and is never
+# sent through the browser or exposed to the renderer process.
+ASSEMBLYAI_API_KEY=
+
 
 # Optional Cloudflare R2 storage. When all four values are set, uploads write through to R2 and local disk acts as a cache.
 # Create a bucket and an Object Read & Write API token in R2. The bucket may remain private; reads use the local service.

--- a/README.md
+++ b/README.md
@@ -262,6 +262,10 @@ http://localhost:5199
 
 Only add the model or media-service credentials you actually use to `.env.local`. Features without configured third-party credentials report the missing key explicitly; local timeline editing, built-in media, and other configured capabilities continue to work.
 
+### AssemblyAI transcription
+
+Set `ASSEMBLYAI_API_KEY` in `.env.local`, or save it in **Settings → Transcription**. The key is stored only in the server-side keystore and the ignored `.env.local` file. When transcribing locally uploaded media, OpenChatCut extracts a compact speech track and streams it directly from the local server to AssemblyAI; the browser does not proxy the audio or receive the key.
+
 Local H.264 exports automatically prefer VideoToolbox on macOS and NVENC on compatible Windows systems, then fall back to software encoding. Tune render concurrency and the heavy-export limit with `OPENCHATCUT_RENDER_CONCURRENCY` and `OPENCHATCUT_MAX_ACTIVE_EXPORTS`, disable hardware encoding with `OPENCHATCUT_DISABLE_HARDWARE_ENCODING`, or override FFmpeg-side encoder selection with `OPENCHATCUT_H264_ENCODER`; see [`.env.example`](.env.example).
 
 ### Desktop development

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -262,6 +262,10 @@ http://localhost:5199
 
 `.env.local` 中只需填写你实际使用的模型或素材服务。没有配置的第三方能力会明确提示缺少对应 Key，不影响本地时间线编辑、内置素材和已配置的其他能力。
 
+### AssemblyAI 转录
+
+在 `.env.local` 中设置 `ASSEMBLYAI_API_KEY`，或在**设置 → 转录**中保存。该 Key 只保存在服务端 keystore 和已被 Git 忽略的 `.env.local` 中。本地上传的媒体转录时，OpenChatCut 会先提取紧凑的语音音轨，再从本地服务端直接流式上传至 AssemblyAI；浏览器既不会代理音频，也不会获取 Key。
+
 本地 H.264 导出会在 macOS 上优先使用 VideoToolbox，在兼容的 Windows 设备上优先使用 NVENC，失败时自动回退软件编码。可用 `OPENCHATCUT_RENDER_CONCURRENCY` 和 `OPENCHATCUT_MAX_ACTIVE_EXPORTS` 调整渲染并发及重型导出上限，用 `OPENCHATCUT_DISABLE_HARDWARE_ENCODING` 关闭硬件编码，或用 `OPENCHATCUT_H264_ENCODER` 覆盖 FFmpeg 侧的编码器选择；详见 [`.env.example`](.env.example)。
 
 ### 桌面端开发

--- a/server/plugins/assemblyai-upload.ts
+++ b/server/plugins/assemblyai-upload.ts
@@ -1,0 +1,74 @@
+import type { Plugin } from 'vite';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { Readable } from 'node:stream';
+import { getKey } from '../keystore.ts';
+import { isSafeUploadName, resolveUploadFile } from '../media-dir.ts';
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(body));
+}
+
+async function readJson(req: IncomingMessage): Promise<{ src?: string }> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk));
+  return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}') as { src?: string };
+}
+
+function uploadName(src: string): string | null {
+  const match = decodeURIComponent(src.split('?')[0] ?? '').match(/^\/media\/uploads\/([^/]+)$/);
+  return match?.[1] && isSafeUploadName(match[1]) ? match[1] : null;
+}
+
+export function assemblyAiUploadPlugin(): Plugin {
+  return {
+    name: 'openchatcut-assemblyai-upload',
+    configureServer(server) {
+      server.middlewares.use('/api/assemblyai-upload', async (req, res) => {
+        if (req.method !== 'POST') {
+          sendJson(res, 405, { error: 'method not allowed' });
+          return;
+        }
+        try {
+          const name = uploadName(String((await readJson(req)).src ?? '').trim());
+          const file = name ? resolveUploadFile(name) : null;
+          const apiKey = getKey('ASSEMBLYAI_API_KEY');
+          if (!file) {
+            sendJson(res, 400, { error: 'src must reference a local uploaded media file' });
+            return;
+          }
+          if (!apiKey) {
+            sendJson(res, 503, { error: 'AssemblyAI API key is not configured' });
+            return;
+          }
+          const info = await stat(file);
+          const started = Date.now();
+          server.config.logger.info(`[assemblyai-upload] starting ${name} (${info.size} bytes)`);
+          const response = await fetch('https://api.assemblyai.com/v2/upload', {
+            method: 'POST',
+            headers: { authorization: apiKey, 'content-type': 'application/octet-stream', 'content-length': String(info.size) },
+            body: Readable.toWeb(createReadStream(file)),
+            duplex: 'half',
+          } as RequestInit);
+          const body = await response.text();
+          if (!response.ok) {
+            server.config.logger.error(`[assemblyai-upload] failed ${name}: HTTP ${response.status} after ${Date.now() - started}ms`);
+            sendJson(res, 502, { error: `AssemblyAI upload failed: HTTP ${response.status}`, detail: body.slice(0, 500) });
+            return;
+          }
+          const parsed = JSON.parse(body) as { upload_url?: string };
+          if (!parsed.upload_url) throw new Error('AssemblyAI returned no upload URL');
+          server.config.logger.info(`[assemblyai-upload] completed ${name} in ${Date.now() - started}ms`);
+          sendJson(res, 200, { uploadUrl: parsed.upload_url, bytes: info.size });
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          server.config.logger.error(`[assemblyai-upload] ${message}`);
+          sendJson(res, 500, { error: message });
+        }
+      });
+    },
+  };
+}

--- a/server/plugins/index.ts
+++ b/server/plugins/index.ts
@@ -12,6 +12,7 @@ import { uploadPlugin } from "./upload.ts";
 import { mobileUploadPlugin } from "./mobile-upload.ts";
 import { uploadMultipartPlugin } from "./upload-multipart.ts";
 import { extractAudioPlugin } from "./extract-audio.ts";
+import { assemblyAiUploadPlugin } from "./assemblyai-upload.ts";
 import { extractFramesPlugin } from "./extract-frames.ts";
 import { sceneDetectionPlugin } from "./scene-detection.ts";
 import { autoGradePlugin } from "./auto-grade.ts";
@@ -52,6 +53,7 @@ export function serverPlugins(): Plugin[] {
     uploadPlugin(),
     mobileUploadPlugin(),
     extractAudioPlugin(),
+    assemblyAiUploadPlugin(),
     extractFramesPlugin(),
     sceneDetectionPlugin(),
     autoGradePlugin(),

--- a/src/transcript/assemblyai.ts
+++ b/src/transcript/assemblyai.ts
@@ -15,6 +15,7 @@ const VIDEO_EXT = /\.(mp4|mov|webm|mkv|m4v|avi|mpeg|mpg)$/i;
 const AUDIO_EXT = /\.(mp3|wav|m4a|aac|ogg|flac|opus)$/i;
 /** Pure audio above this still gets re-encoded smaller for ASR. */
 const LARGE_AUDIO_BYTES = 40 * 1024 * 1024;
+const UPLOAD_TIMEOUT_MS = 10 * 60_000;
 
 export class TranscriptionError extends Error {
   readonly code: 'source-unavailable' | 'service-unavailable';
@@ -40,18 +41,61 @@ async function serviceFetch(input: RequestInfo | URL, init?: RequestInit): Promi
   }
 }
 
-async function uploadBlob(blob: Blob): Promise<string> {
-  const r = await serviceFetch(`${BASE}/upload`, { method: 'POST', body: blob });
-  if (!r.ok) throw new Error(`upload failed: HTTP ${r.status}`);
-  const { upload_url } = await r.json();
-  if (!upload_url) throw new Error('upload: no upload_url returned');
-  return upload_url;
+async function uploadBlob(blob: Blob, opts: TranscribeOptions): Promise<string> {
+  report(opts, 'uploading-audio', `0% of ${Math.ceil(blob.size / 1024 / 1024)} MB`);
+  return new Promise((resolve, reject) => {
+    const request = new XMLHttpRequest();
+    request.open('POST', `${BASE}/upload`);
+    request.timeout = UPLOAD_TIMEOUT_MS;
+    request.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return;
+      const percent = Math.min(100, Math.round((event.loaded / event.total) * 100));
+      report(opts, 'uploading-audio', `${percent}% (${Math.ceil(event.loaded / 1024 / 1024)} / ${Math.ceil(event.total / 1024 / 1024)} MB)`);
+    };
+    request.onerror = () => reject(new TranscriptionError('service-unavailable', 'AssemblyAI upload network error'));
+    request.ontimeout = () => reject(new TranscriptionError('service-unavailable', `AssemblyAI upload timed out after ${Math.round(UPLOAD_TIMEOUT_MS / 60_000)} minutes`));
+    request.onload = () => {
+      if (request.status < 200 || request.status >= 300) {
+        reject(new Error(`AssemblyAI upload failed: HTTP ${request.status}${request.responseText ? `: ${request.responseText.slice(0, 300)}` : ''}`));
+        return;
+      }
+      try {
+        const body = JSON.parse(request.responseText) as { upload_url?: string };
+        if (!body.upload_url) throw new Error('AssemblyAI upload returned no upload URL');
+        resolve(body.upload_url);
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    };
+    request.send(blob);
+  });
+}
+
+async function uploadLocalPath(path: string, opts: TranscribeOptions): Promise<string> {
+  report(opts, 'uploading-audio', 'server-to-AssemblyAI transfer');
+  const response = await serviceFetch('/api/assemblyai-upload', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ src: path }),
+  });
+  if (!response.ok) throw new Error(`AssemblyAI server upload failed: ${await response.text()}`);
+  const body = await response.json() as { uploadUrl?: string; bytes?: number };
+  if (!body.uploadUrl) throw new Error('AssemblyAI server upload returned no upload URL');
+  report(opts, 'uploading-audio', `completed ${Math.ceil((body.bytes ?? 0) / 1024 / 1024)} MB`);
+  return body.uploadUrl;
+}
+
+export type TranscriptionPhase = 'extracting-audio' | 'loading-audio' | 'uploading-audio' | 'creating-job' | 'queued' | 'processing' | 'completed';
+
+export interface TranscriptionProgress {
+  phase: TranscriptionPhase;
+  detail?: string;
 }
 
 export interface TranscribeOptions {
   /**
-   * ISO-639-1. Default `zh` for this product (Chinese oral broadcast).
-   * Pass `auto` to use AssemblyAI language_detection instead.
+   * ISO-639-1, or `auto` to use AssemblyAI language detection.
+   * Defaults to `auto` so English and multilingual media work without setup.
    */
   languageCode?: string | 'auto';
   /**
@@ -59,9 +103,15 @@ export interface TranscribeOptions {
    * When set, skip another extract-audio call.
    */
   asrPath?: string | null;
+  onProgress?: (event: TranscriptionProgress) => void;
 }
 
-async function createTranscript(audioUrl: string, opts: TranscribeOptions = {}): Promise<string> {
+function report(opts: TranscribeOptions, phase: TranscriptionPhase, detail?: string): void {
+  console.info('[transcription]', phase, detail ?? '');
+  opts.onProgress?.({ phase, detail });
+}
+
+export async function createTranscript(audioUrl: string, opts: TranscribeOptions = {}): Promise<string> {
   const body: Record<string, unknown> = {
     audio_url: audioUrl,
     speaker_labels: true,
@@ -69,29 +119,30 @@ async function createTranscript(audioUrl: string, opts: TranscribeOptions = {}):
     punctuate: true,
     format_text: true,
   };
-  const lang = opts.languageCode ?? 'zh';
+  const lang = opts.languageCode ?? 'auto';
   if (lang === 'auto') {
     body.language_detection = true;
   } else {
-    // Explicit zh is far more reliable for Chinese documentary oral broadcast than pure auto-detect.
     body.language_code = lang;
   }
+  report(opts, 'creating-job', opts.languageCode === 'auto' || !opts.languageCode ? 'automatic language detection' : `language ${opts.languageCode}`);
   const r = await serviceFetch(`${BASE}/transcript`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify(body),
   });
-  if (!r.ok) throw new Error(`create failed: HTTP ${r.status}`);
+  if (!r.ok) throw new Error(`AssemblyAI job creation failed: HTTP ${r.status}`);
   const { id, error } = await r.json();
   if (error) throw new Error(error);
   if (!id) throw new Error('transcript: no id returned');
   return id;
 }
 
-async function poll(id: string, onWait?: () => void): Promise<TranscriptResult> {
+async function poll(id: string, opts: TranscribeOptions): Promise<TranscriptResult> {
+  let previousStatus = '';
   for (;;) {
     const r = await serviceFetch(`${BASE}/transcript/${id}`);
-    if (!r.ok) throw new Error(`poll failed: HTTP ${r.status}`);
+    if (!r.ok) throw new Error(`AssemblyAI status check failed: HTTP ${r.status}`);
     const d = await r.json();
     if (d.status === 'completed') {
       const mapW = (w: { text: string; start: number; end: number; speaker?: string | null }) => ({
@@ -113,10 +164,14 @@ async function poll(id: string, onWait?: () => void): Promise<TranscriptResult> 
             : [{ text: u.text, start: u.start, end: u.end, speaker: u.speaker }]),
         );
       }
+      report(opts, 'completed', `${words.length} words`);
       return { text: d.text ?? words.map((w: { text: string }) => w.text).join(''), words, utterances };
     }
-    if (d.status === 'error') throw new Error(d.error ?? 'transcription error');
-    onWait?.();
+    if (d.status === 'error') throw new Error(`AssemblyAI transcription failed: ${d.error ?? 'unknown error'}`);
+    if (d.status !== previousStatus) {
+      previousStatus = d.status;
+      report(opts, d.status === 'queued' ? 'queued' : 'processing', `job ${id.slice(0, 8)}`);
+    }
     await new Promise((res) => setTimeout(res, 2500));
   }
 }
@@ -124,12 +179,11 @@ async function poll(id: string, onWait?: () => void): Promise<TranscriptResult> 
 /** Transcribe an audio Blob: upload → create → poll to completion. */
 export async function transcribeBlob(
   blob: Blob,
-  onWait?: () => void,
   opts: TranscribeOptions = {},
 ): Promise<TranscriptResult> {
-  const url = await uploadBlob(blob);
+  const url = await uploadBlob(blob, opts);
   const id = await createTranscript(url, opts);
-  return poll(id, onWait);
+  return poll(id, opts);
 }
 
 /** Read a media source, falling back to the local-first IndexedDB copy. */
@@ -194,16 +248,22 @@ async function shouldExtractForAsr(path: string): Promise<boolean> {
  */
 export async function transcribePath(
   path: string,
-  onWait?: () => void,
   opts: TranscribeOptions = {},
 ): Promise<TranscriptResult> {
   let source = path;
   if (opts.asrPath && opts.asrPath.startsWith('/media/')) {
     source = opts.asrPath;
   } else if (await shouldExtractForAsr(path)) {
+    report(opts, 'extracting-audio');
     const extracted = await extractAudioForAsr(path);
     if (extracted) source = extracted;
   }
+  if (source.startsWith('/media/uploads/')) {
+    const url = await uploadLocalPath(source, opts);
+    const id = await createTranscript(url, opts);
+    return poll(id, opts);
+  }
+  report(opts, 'loading-audio', source === path ? 'original media' : 'extracted speech audio');
   let blob: Blob;
   try {
     blob = await loadTranscriptionSource(source);
@@ -213,5 +273,5 @@ export async function transcribePath(
     if (source === path) throw error;
     blob = await loadTranscriptionSource(path);
   }
-  return transcribeBlob(blob, onWait, { languageCode: opts.languageCode });
+  return transcribeBlob(blob, opts);
 }


### PR DESCRIPTION
## Summary

- Route local `/media/uploads/...` transcription sources through a new server-side streaming endpoint instead of uploading extracted audio through the browser proxy path
- Keep the AssemblyAI credential in the server keystore only, validate local source paths, and return only the upstream upload URL to the browser
- Expose transcription upload/job progress with phase-based detail, retain blob upload as a fallback, and document `ASSEMBLYAI_API_KEY` setup without including any credential value

## Root Cause

Large extracted audio uploads could stall partway through the browser-to-proxy transfer before AssemblyAI returned an upload URL. Since no upload URL or transcript job existed, polling could not recover the request. The root cause was the browser proxy path for multi-megabyte audio transfers through Vite's dev server proxy.

## Resolution

The editor now sends only the same-origin media path to `/api/assemblyai-upload`. The OpenChatCut server resolves the safe local file and streams it directly to AssemblyAI with the server-side key. This bypasses the browser/public-proxy transfer while preserving the existing AssemblyAI transcript creation and polling flow.

### Files changed

| File | Change |
|------|--------|
| `server/plugins/assemblyai-upload.ts` | **New** — server-side plugin that accepts safe `/media/uploads/<name>` paths, streams them to AssemblyAI's upload endpoint, and returns the upload URL |
| `server/plugins/index.ts` | Register the new plugin |
| `src/transcript/assemblyai.ts` | Route local media through the new server endpoint, add XHR upload progress, 10-minute timeout, phase-based progress reporting, and automatic language detection |
| `.env.example` | Add `ASSEMBLYAI_API_KEY` with server-side security note |
| `README.md` | Add AssemblyAI transcription setup section |
| `README_ZH.md` | Add Chinese AssemblyAI transcription setup section |

## Security

- `ASSEMBLYAI_API_KEY` is read with the server-only keystore API and never exposed to the browser
- The endpoint accepts only safe single-file `/media/uploads/<name>` paths via `isSafeUploadName()` + `resolveUploadFile()`
- `.env.local` remains gitignored and is not included in this PR
- The browser receives no credential, only the resulting AssemblyAI upload URL

## Verification

- `npm run lint` — passed
- `npx tsx src/transcript/assemblyai.verify.ts` — passed
- `npm test` — full test suite passed
- `npm run build` — production build succeeded
- Manual local verification: saved the key through the Settings API, confirmed configured status without reading the credential, passed AssemblyAI's HTTP 200 connection probe, and completed a full transcription using the new direct server upload path