### PR TITLE
fix(export): make desktop rendering durable and offline-safe

### DIFF
--- a/assets/fonts/HarmonyOS-Sans-License.txt
+++ b/assets/fonts/HarmonyOS-Sans-License.txt
@@ -1,0 +1,33 @@
+License Notice
+Copyright 2021 Huawei Device Co., Ltd.
+HarmonyOS Sans Fonts Software is licensed under HarmonyOS Sans Fonts License Agreement.
+
+--------------------------------------------------------------------------------
+HarmonyOS Sans Fonts License Agreement
+
+THIS HARMONYOS SANS FONTS LICENSE AGREEMENT ("AGREEMENT") IS A LEGAL AGREEMENT BETWEEN YOU (EITHER A SINGLE INDIVIDUAL, OR SINGLE LEGAL ENTITY) AND HUAWEI DEVICE CO., LTD.( "LICENSOR")FOR THE USE OF THE HARMONYOS SANS FONTS ACCOMPANYING THIS AGREEMENT.BY DOWNLOADING,COPYING OR OTHERWISE USING HARMONYOS SANS FONTS YOU INDICATE THAT YOU AGREE TO BE BOUND BY ALL OF THE TERMS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO THE TERMS OF THIS AGREEMENT, YOU MAY NOT DOWNLOAD, COPY OR OTHERWISE USE THE HARMONYOS SANS FONTS, AND YOU SHALL PROMPTLY DESTROY AND DELETE ALL THE HARMONYOS SANS FONTS.
+
+1.Definition
+"HarmonyOS Sans Fonts" shall mean the collection of fonts software components provided by Licensor under this Agreement and clearly marked as "HarmonyOS¬ Sans".
+
+"YOU" shall mean an individual or legal entity exercising permissions granted by this Agreement.
+
+2.GRANT OF LICENSE
+
+Subject to the terms and conditions of this Agreement, Licensor hereby grant YOU a non-transferable, non-exclusive, royalty-free, revocable, worldwide copyright license to use,copy, merge, embed, bundle, redistribute and/or sell unmodified copies of HarmonyOS Sans Fonts with any software except for fonts software，subject to the  following conditions:
+1)YOU shall make a prominent notice in the software to state that HarmonyOS Sans Fonts are used.
+2)YOU may not make any modifications to HarmonyOS Sans Fonts or any of their individual components.
+3)Neither HarmonyOS Sans Fonts nor any of their individual components may be redistributed or sold in a stand-alone base. This limitation does not apply to any work created by using HarmonyOS Sans Fonts. You can freely distribute or sell your work, such as materials, logos, application software etc. created by using HarmonyOS Sans Fonts.
+4)YOU shall retain the copyright notice and this Agreement in any copies of HarmonyOS Sans Fonts.
+
+3.Termination
+This Agreement will be automatically terminated if YOU breach any of this Agreement.
+
+4.NO WARRANTY
+YOU AGREE THAT THE HARMONYOS SANS FONTS ARE PROVIDED BY LICENSOR ON AN "AS IS" BASIS. LICENSOR MAKES NO WARRANTY, EXPRESSED OR IMPLIED OR STATUTORY, WITH RESPECT TO ANY OF THE HARMONYOS SANS FONTS, INCLUDING WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF MERCHANTABILITY, SATISFACTORY QUALITY, FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT.
+
+5.NO LIABILITY
+
+IN NO EVENT SHALL LICENSOR BE LIABLE FOR ANY DIRECT OR INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) ARISING IN ANY WAY OUT OF THE USE OF OR INABILITY TO USE HARMONYOS SANS FONTS, WHETHER UNDER THEORY OF CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT LIABILITY OR OTHER LEGAL THEORY, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+YOU EXPRESSLY ASSUME ALL LIABILITIES AND RISKS FOR USE OF HARMONYOS SANS FONTS. SHOULD THE HARMONYOS SANS FONTS PROVE DEFECTIVE, YOU ASSUME THE ENTIRE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.

--- a/assets/fonts/LICENSES.md
+++ b/assets/fonts/LICENSES.md
@@ -16,3 +16,9 @@ The other bundled fonts use their publishers' free-commercial-use terms and
 are not open-source fonts: HarmonyOS Sans, Huxiaobo Nanshen Ti,
 Huxiaobo Saobao Ti, Huxiaobo Zhenshuai Ti, Pangmen Zhengdao Biaoti Ti and
 Pangmen Zhengdao Qingsong Ti.
+
+## HarmonyOS Sans notice
+
+This software uses and bundles unmodified HarmonyOS Sans Fonts. Copyright 2021
+Huawei Device Co., Ltd. The complete agreement retained with the font copies is
+in [`HarmonyOS-Sans-License.txt`](HarmonyOS-Sans-License.txt).

--- a/desktop/export-reveal.ts
+++ b/desktop/export-reveal.ts
@@ -1,0 +1,8 @@
+import { isAbsolute, basename, join } from 'node:path';
+
+/** Resolve only a direct child of a trusted export directory. */
+export function exportRevealCandidate(directory: string, filename: unknown): string | null {
+  if (!isAbsolute(directory) || typeof filename !== 'string' || !filename) return null;
+  if (basename(filename) !== filename || filename === '.' || filename === '..') return null;
+  return join(directory, filename);
+}

--- a/desktop/export-reveal.verify.ts
+++ b/desktop/export-reveal.verify.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { exportRevealCandidate } from './export-reveal.ts';
+
+assert.equal(exportRevealCandidate('/tmp/exports', 'demo.mp4'), '/tmp/exports/demo.mp4');
+assert.equal(exportRevealCandidate('/tmp/exports', '../demo.mp4'), null, 'filenames must not escape the export directory');
+assert.equal(exportRevealCandidate('/tmp/exports', '/tmp/demo.mp4'), null, 'absolute filenames must be rejected');
+assert.equal(exportRevealCandidate('relative', 'demo.mp4'), null, 'the export directory must be absolute');
+
+const main = readFileSync(new URL('./main.ts', import.meta.url), 'utf8');
+const preload = readFileSync(new URL('./preload.ts', import.meta.url), 'utf8');
+const history = readFileSync(new URL('../src/components/ExportHistory.tsx', import.meta.url), 'utf8');
+const english = readFileSync(new URL('../src/i18n/dict/en/components.ts', import.meta.url), 'utf8');
+assert.match(main, /openchatcut:reveal-export/, 'Electron main must own the filesystem reveal operation');
+assert.match(preload, /revealExport\(filename: string\)/, 'the preload bridge must expose a narrow reveal method');
+assert.match(history, /openChatCutDesktop\?\.revealExport/, 'export history must offer reveal only when desktop support exists');
+assert.match(history, /revealExport\(r\.name\)\.catch\(\(\) => undefined\)/, 'a rejected native reveal must not become an unhandled UI rejection');
+assert.match(english, /'打开文件夹': 'Open Folder'/, 'the new export action must stay localized in English');
+
+console.log('export-reveal.verify: history reveal stays inside the trusted desktop boundary');

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -1,12 +1,14 @@
 import './chdir-first.ts';
 import { randomUUID } from 'node:crypto';
+import { existsSync } from 'node:fs';
 import { mkdir, readFile, realpath, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { app, BrowserWindow, dialog, ipcMain, type OpenDialogOptions } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, shell, type OpenDialogOptions } from 'electron';
 import { startEmbeddedServer } from './embedded-server.ts';
 import { preparePackagedRuntime } from './packaged-runtime.ts';
 import { createExportDirectoryGrant } from '../server/export-destinations.ts';
+import { exportRevealCandidate } from './export-reveal.ts';
 
 // Electron main process entry. dev mode: esbuild hits desktop-dist/main.mjs,dist/ in the codebase root;
 // Packaging form: dist/, resonance-bundle, chrome-headless-shell use extraResources.
@@ -100,6 +102,16 @@ function registerDesktopHandlers(): void {
   ipcMain.handle('openchatcut:restore-export-directory', async () => {
     const directory = await restorePersistedExportDirectory(exportStatePath);
     return directory ? createExportDirectoryGrant(directory) : null;
+  });
+  ipcMain.handle('openchatcut:reveal-export', async (_event, filename: unknown) => {
+    const directory = await restorePersistedExportDirectory(exportStatePath) ?? app.getPath('downloads');
+    const candidate = exportRevealCandidate(directory, filename);
+    if (candidate && existsSync(candidate)) {
+      shell.showItemInFolder(candidate);
+      return;
+    }
+    const error = await shell.openPath(directory);
+    if (error) throw new Error(error);
   });
 }
 

--- a/desktop/preload.ts
+++ b/desktop/preload.ts
@@ -9,6 +9,7 @@ export interface OpenChatCutDesktopApi {
   selectDirectory(defaultPath?: string): Promise<string | null>;
   selectExportDirectory(): Promise<DesktopExportDirectoryGrant | null>;
   restoreExportDirectory(): Promise<DesktopExportDirectoryGrant | null>;
+  revealExport(filename: string): Promise<void>;
 }
 
 const api: OpenChatCutDesktopApi = {
@@ -18,6 +19,8 @@ const api: OpenChatCutDesktopApi = {
     ipcRenderer.invoke('openchatcut:select-export-directory') as Promise<DesktopExportDirectoryGrant | null>,
   restoreExportDirectory: () =>
     ipcRenderer.invoke('openchatcut:restore-export-directory') as Promise<DesktopExportDirectoryGrant | null>,
+  revealExport: (filename) =>
+    ipcRenderer.invoke('openchatcut:reveal-export', filename) as Promise<void>,
 };
 
 contextBridge.exposeInMainWorld('openChatCutDesktop', api);

--- a/remotion/render-timeout.mjs
+++ b/remotion/render-timeout.mjs
@@ -1,0 +1,10 @@
+const DEFAULT_RENDER_TIMEOUT_MS = 120_000;
+const MIN_RENDER_TIMEOUT_MS = 30_000;
+const MAX_RENDER_TIMEOUT_MS = 600_000;
+
+/** Keep slow local initialization recoverable without allowing an unbounded hang. */
+export function resolveRenderTimeout(raw = process.env.CC_RENDER_TIMEOUT_MS) {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_RENDER_TIMEOUT_MS;
+  return Math.min(MAX_RENDER_TIMEOUT_MS, Math.max(MIN_RENDER_TIMEOUT_MS, Math.round(parsed)));
+}

--- a/remotion/render-timeout.verify.mjs
+++ b/remotion/render-timeout.verify.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { resolveRenderTimeout } from './render-timeout.mjs';
+
+assert.equal(resolveRenderTimeout(undefined), 120_000, 'export initialization should allow slow local font and media setup');
+assert.equal(resolveRenderTimeout('90000'), 90_000, 'operators may lower the timeout explicitly');
+assert.equal(resolveRenderTimeout('9999999'), 600_000, 'the override must remain bounded');
+assert.equal(resolveRenderTimeout('not-a-number'), 120_000, 'invalid overrides must use the safe default');
+
+console.log('render-timeout.verify: export initialization timeout is bounded and configurable');

--- a/remotion/render.mjs
+++ b/remotion/render.mjs
@@ -16,6 +16,7 @@ import {
   resolveRenderConcurrency,
   withEncoderProfileFallback,
 } from './performance.mjs';
+import { resolveRenderTimeout } from './render-timeout.mjs';
 
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const ENTRY_POINT = path.join(REPO_ROOT, 'remotion', 'index.ts');
@@ -25,6 +26,7 @@ const ASSETS_DIR = path.join(REPO_ROOT, 'assets');
 const PUBLIC_DIR = path.join(REPO_ROOT, 'public');
 const UPLOAD_DIR = path.join(PUBLIC_DIR, 'media', 'uploads');
 const COMPOSITION_ID = 'timeline';
+const renderTimeoutInMilliseconds = () => resolveRenderTimeout();
 
 const H264_PROFILE_LABELS = {
   h264_videotoolbox: 'Apple VideoToolbox',
@@ -415,6 +417,7 @@ export async function renderTimeline({
   const inputProps = { state, project, timelineId };
   const composition = await selectComposition({
     serveUrl, id: COMPOSITION_ID, inputProps, browserExecutable: browserExecutable(),
+    timeoutInMilliseconds: renderTimeoutInMilliseconds(),
   });
   signal?.throwIfAborted();
   const rendered = await renderMediaOptimized({
@@ -434,6 +437,7 @@ export async function renderTimeline({
     browserExecutable: browserExecutable(),
     onProgress: onProgress ? ({ progress }) => onProgress(progress) : undefined,
     cancelSignal,
+    timeoutInMilliseconds: renderTimeoutInMilliseconds(),
   });
   return {
     outputLocation,
@@ -461,16 +465,20 @@ export async function renderClip({
   transparent = true,
   h264Profile,
   vaapiDevice,
+  signal,
 }) {
   if (!state || !Array.isArray(state.items) || !state.items.length) {
     throw new Error('renderClip: a single-item TimelineState is required');
   }
   if (!outputLocation) throw new Error('renderClip: outputLocation is required');
+  signal?.throwIfAborted();
   assertMaterializedRenderSnapshot(state, 'renderClip');
+  const cancelSignal = remotionCancelSignal(signal);
   const serveUrl = await getServeUrl();
   const inputProps = { state, transparent };
   const composition = await selectComposition({
     serveUrl, id: COMPOSITION_ID, inputProps, browserExecutable: browserExecutable(),
+    timeoutInMilliseconds: renderTimeoutInMilliseconds(),
   });
   await renderMediaOptimized({
     serveUrl,
@@ -485,6 +493,8 @@ export async function renderClip({
       : {}),
     chromiumOptions: { gl: 'angle' },
     browserExecutable: browserExecutable(),
+    timeoutInMilliseconds: renderTimeoutInMilliseconds(),
+    cancelSignal,
   });
   return outputLocation;
 }
@@ -521,6 +531,7 @@ export async function renderTimelineStills({ state, project, timelineId, frames,
       serveUrl, id: COMPOSITION_ID, inputProps,
       puppeteerInstance: browser,
       browserExecutable: browserExecutable(),
+      timeoutInMilliseconds: renderTimeoutInMilliseconds(),
     });
     const out = [];
     const list = frames.slice(0, STILL_MAX_FRAMES);
@@ -536,6 +547,7 @@ export async function renderTimelineStills({ state, project, timelineId, frames,
         offthreadVideoThreads: offthreadVideoThreads(),
         output: null,
         puppeteerInstance: browser,
+        timeoutInMilliseconds: renderTimeoutInMilliseconds(),
       });
       out.push({ frame: f, base64: buffer.toString('base64') });
     }

--- a/server/plugins/export.ts
+++ b/server/plugins/export.ts
@@ -336,6 +336,10 @@ export function exportPlugin(): Plugin {
         let tmpOut: string | null = null;
         let bakeOut: string | null = null;
         let cleanupRenderMedia: (() => Promise<void>) | undefined;
+        const controller = new AbortController();
+        const cancel = () => controller.abort();
+        req.once('aborted', cancel);
+        res.once('close', cancel);
         try {
           const body = (await readJsonBody(req)) as { state?: unknown; codec?: string; transparent?: boolean; mode?: string; filename?: string } | null;
           const state = body?.state;
@@ -360,6 +364,7 @@ export function exportPlugin(): Plugin {
               codec,
               transparent,
               ...await h264RenderOptions(codec),
+              signal: controller.signal,
             }));
             bakeOut = null;
             res.statusCode = 200;
@@ -373,6 +378,7 @@ export function exportPlugin(): Plugin {
               codec,
               transparent,
               ...await h264RenderOptions(codec),
+              signal: controller.signal,
             }));
             const buf = await readFile(tmpOut);
             const safe = sanitizeFileName(body?.filename ?? 'clip', 'clip');
@@ -383,6 +389,7 @@ export function exportPlugin(): Plugin {
             res.end(buf);
           }
         } catch (err) {
+          if (controller.signal.aborted) return;
           const message = err instanceof Error ? err.message : String(err);
           server.config.logger.error(`[render-clip] ${message}`);
           const failure = exportFailureFrom(err);
@@ -394,6 +401,8 @@ export function exportPlugin(): Plugin {
           if (tmpOut) await unlink(tmpOut).catch(() => {});
           if (bakeOut) await unlink(bakeOut).catch(() => {});
           await cleanupRenderMedia?.();
+          req.removeListener('aborted', cancel);
+          res.removeListener('close', cancel);
         }
       });
 

--- a/server/plugins/render-clip-cancellation.verify.ts
+++ b/server/plugins/render-clip-cancellation.verify.ts
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const plugin = readFileSync(new URL('./export.ts', import.meta.url), 'utf8');
+const renderer = readFileSync(new URL('../../remotion/render.mjs', import.meta.url), 'utf8');
+
+assert.match(
+  plugin,
+  /server\.middlewares\.use\('\/render-clip'[\s\S]*?new AbortController\(\)[\s\S]*?req\.once\('aborted'[\s\S]*?signal: controller\.signal/,
+  'aborting an MG export request must stop the server-side clip render',
+);
+assert.match(
+  renderer,
+  /export async function renderClip\(\{[\s\S]*?signal[\s\S]*?cancelSignal/,
+  'the clip renderer must bridge AbortSignal to Remotion cancellation',
+);
+assert.match(
+  plugin,
+  /catch \(err\) \{\s*if \(controller\.signal\.aborted\) return;/,
+  'an expected client disconnect must not be logged or answered as a server failure',
+);
+
+console.log('render-clip-cancellation.verify: aborted MG requests stop local rendering');

--- a/src/components/ExportHistory.tsx
+++ b/src/components/ExportHistory.tsx
@@ -82,6 +82,13 @@ export function ExportHistory() {
                       <div style={{ fontSize: 13, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.name}</div>
                       <div style={{ fontSize: 11, color: theme.textDim }}>{meta(r)} · {relTime(r.createdAt)}</div>
                     </div>
+                    {window.openChatCutDesktop?.revealExport && (
+                      <button type="button" onClick={() => { void window.openChatCutDesktop?.revealExport(r.name).catch(() => undefined); }}
+                        aria-label={t('打开文件夹')} title={t('打开文件夹')} style={folderBtn}>
+                        <Icon name="folder" size={14} />
+                        <span>{t('打开文件夹')}</span>
+                      </button>
+                    )}
                   </div>
                 ))
               )}
@@ -117,4 +124,9 @@ const iconBtn: React.CSSProperties = { background: 'none', border: 'none', color
 const ghostBtn: React.CSSProperties = {
   background: 'none', border: `0.5px solid ${theme.border}`, color: theme.text,
     borderRadius: 4, padding: '5px 12px', fontSize: 12.5, whiteSpace: 'nowrap',
+};
+const folderBtn: React.CSSProperties = {
+  height: 28, flex: '0 0 auto', display: 'inline-flex', alignItems: 'center', gap: 5,
+  padding: '0 9px', border: `0.5px solid ${theme.border}`, borderRadius: 4,
+  background: 'transparent', color: theme.textDim, cursor: 'pointer', fontSize: 11.5,
 };

--- a/src/desktop-api.d.ts
+++ b/src/desktop-api.d.ts
@@ -10,6 +10,7 @@ declare global {
       selectDirectory(defaultPath?: string): Promise<string | null>;
       selectExportDirectory(): Promise<DesktopExportDirectoryGrant | null>;
       restoreExportDirectory(): Promise<DesktopExportDirectoryGrant | null>;
+      revealExport(filename: string): Promise<void>;
     };
   }
 }

--- a/src/export/export-reliability.verify.ts
+++ b/src/export/export-reliability.verify.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const model = readFileSync(new URL('./useExportDialogModel.ts', import.meta.url), 'utf8');
+
+assert.match(
+  model,
+  /export const DEFAULT_INCLUDE_MG = true;/,
+  'editable-project exports should include rendered motion graphics by default',
+);
+assert.match(
+  model,
+  /useState\(DEFAULT_INCLUDE_MG\)/,
+  'the dialog state must use the documented default instead of duplicating a literal',
+);
+
+console.log('export-reliability.verify: editable-project exports default to complete MG packages');

--- a/src/export/useExportDialogModel.ts
+++ b/src/export/useExportDialogModel.ts
@@ -52,6 +52,7 @@ export const EXPORT_ACTION_LABELS: Record<ExportTab, string> = {
 
 export const EXPORT_FPS = [...EXPORT_FPS_OPTIONS];
 export const EXPORT_RESOLUTION_OPTIONS = Object.keys(EXPORT_RESOLUTIONS) as ExportResolution[];
+export const DEFAULT_INCLUDE_MG = true;
 
 export interface ExportVideoSettings {
   codec: 'h264' | 'vp8';
@@ -182,7 +183,7 @@ export function useExportDialogModel({ state, project, projectId, projectName, e
   const video = useVideoSettings(state);
   const subtitles = useSubtitleSettings(state);
   const [nleFormat, setNleFormat] = useState<'fcp_xml' | 'fcp_xml_resolve'>('fcp_xml');
-  const [includeMg, setIncludeMg] = useState(false);
+  const [includeMg, setIncludeMg] = useState(DEFAULT_INCLUDE_MG);
   const mgItems = useMemo(() => state.items.filter((item) => item.kind === 'motion-graphic'), [state.items]);
   const base = sanitizeFileName(projectName, 'export');
   const workflow = useExportWorkflow({

--- a/src/fonts/googleFontCatalog.ts
+++ b/src/fonts/googleFontCatalog.ts
@@ -9,7 +9,6 @@ export interface FontCatalogEntry {
 
 export interface GoogleFontCatalogEntry extends FontCatalogEntry {
   source: 'google';
-  weighted?: boolean;
 }
 
 export const GOOGLE_FONT_CATALOG: readonly GoogleFontCatalogEntry[] = [
@@ -31,7 +30,6 @@ export const GOOGLE_FONT_CATALOG: readonly GoogleFontCatalogEntry[] = [
   { family: 'Montserrat', aliases: [], loadable: true, source: 'google' },
   { family: 'Mulish', aliases: [], loadable: true, source: 'google' },
   { family: 'Newsreader', aliases: [], loadable: true, source: 'google' },
-  { family: 'Noto Sans SC', aliases: ['Noto Sans CJK SC'], loadable: true, source: 'google', weighted: true },
   { family: 'Noto Serif SC', aliases: [], loadable: true, source: 'google' },
   { family: 'Noto Serif TC', aliases: [], loadable: true, source: 'google' },
   { family: 'Nunito', aliases: [], loadable: true, source: 'google' },

--- a/src/fonts/googleFonts.ts
+++ b/src/fonts/googleFonts.ts
@@ -20,13 +20,9 @@ interface FontLoadResult {
   waitUntilDone: () => Promise<void>;
 }
 
-type NotoSansSCWeight =
-  | '100' | '200' | '300' | '400' | '500'
-  | '600' | '700' | '800' | '900';
-
 // Runtime-selected, finite imports are intentional: Vite emits one discoverable
 // chunk per family instead of bundling every @remotion/google-fonts loader.
-async function loadGoogleFace(family: string, fontWeight = 400): Promise<FontLoadResult> {
+async function loadGoogleFace(family: string): Promise<FontLoadResult> {
   switch (family) {
     case 'Anton': return (await import('@remotion/google-fonts/Anton')).loadFont();
     case 'Archivo Black': return (await import('@remotion/google-fonts/ArchivoBlack')).loadFont();
@@ -59,15 +55,6 @@ async function loadGoogleFace(family: string, fontWeight = 400): Promise<FontLoa
     case 'Unbounded': return (await import('@remotion/google-fonts/Unbounded')).loadFont();
     case 'VT323': return (await import('@remotion/google-fonts/VT323')).loadFont();
     case 'ZCOOL QingKe HuangYou': return (await import('@remotion/google-fonts/ZCOOLQingKeHuangYou')).loadFont();
-    case 'Noto Sans SC': {
-      const rounded = Math.min(900, Math.max(100, Math.round(fontWeight / 100) * 100));
-      const weight = String(rounded) as NotoSansSCWeight;
-      return (await import('@remotion/google-fonts/NotoSansSC')).loadFont('normal', {
-        weights: [weight],
-        subsets: ['chinese-simplified', 'latin'],
-        ignoreTooManyRequestsWarning: true,
-      });
-    }
     default:
       throw new Error(`font loader unavailable: ${family}`);
   }
@@ -76,7 +63,7 @@ async function loadGoogleFace(family: string, fontWeight = 400): Promise<FontLoa
 const fontPromises = new Map<string, Promise<void>>();
 
 /** Load one referenced face and resolve only after browser/headless readiness. */
-export function ensureFont(family: string, fontWeight = 400): Promise<void> {
+export function ensureFont(family: string, _fontWeight = 400): Promise<void> {
   if (isGenericFontFamily(family)) return Promise.resolve();
   const canonical = resolveCanonicalFamily(family);
   if (!canonical) return Promise.resolve();
@@ -84,10 +71,10 @@ export function ensureFont(family: string, fontWeight = 400): Promise<void> {
   const metadata = GOOGLE_FONT_CATALOG.find((entry) => entry.family === canonical);
   if (!metadata) return Promise.resolve();
 
-  const faceKey = metadata.weighted ? `${canonical}:${fontWeight}` : canonical;
+  const faceKey = canonical;
   const cached = fontPromises.get(faceKey);
   if (cached) return cached;
-  const promise = loadGoogleFace(canonical, fontWeight)
+  const promise = loadGoogleFace(canonical)
     .then((font) => font.waitUntilDone())
     .catch((error: unknown) => {
       fontPromises.delete(faceKey);

--- a/src/fonts/localFonts.ts
+++ b/src/fonts/localFonts.ts
@@ -32,6 +32,14 @@ export interface LocalCjkFont {
 
 // License by style (all are public and free licensed fonts):
 export const LOCAL_CJK_FONTS: readonly LocalCjkFont[] = [
+  // Offline compatibility face for existing projects and built-in templates.
+  // The Google Fonts Noto Sans SC subset expands into many remote shards, which
+  // can hold Remotion's initial render open on slow or disconnected machines.
+  // Reuse the already-bundled HarmonyOS Sans bytes under the historical family
+  // name so those projects render without migration or network access.
+  { family: 'Noto Sans SC', importName: 'NotoSansSC', aliasZh: ['Noto Sans CJK SC', '思源黑体'],
+    files: { 400: '/fonts/harmonyos-sans/HarmonyOS_Sans_SC_Regular.woff2',
+             700: '/fonts/harmonyos-sans/HarmonyOS_Sans_SC_Bold.woff2' } },
   // Deyihei — SIL Open Font License 1.1(github.com/atelier-anchor/smiley-sans, v2.0.1)
   { family: 'Smiley Sans', importName: 'SmileySans', aliasZh: ['得意黑'],
     files: { 400: '/fonts/smiley-sans/SmileySans-Oblique.woff2' } },

--- a/src/fonts/notoSansOffline.verify.ts
+++ b/src/fonts/notoSansOffline.verify.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { FONT_CATALOG } from './googleFontCatalog';
+import { findLocalFont } from './localFonts';
+
+const googleFontsSource = readFileSync(new URL('./googleFonts.ts', import.meta.url), 'utf8');
+
+assert.doesNotMatch(
+  googleFontsSource,
+  /@remotion\/google-fonts\/NotoSansSC|NotoSansSCWeight/,
+  'Noto Sans SC must not start the remote multi-shard Google Fonts loader during export',
+);
+
+const localFace = findLocalFont('Noto Sans SC');
+assert.ok(localFace, 'Noto Sans SC must resolve to an offline bundled face');
+assert.equal(localFace.family, 'Noto Sans SC');
+assert.equal(findLocalFont('Noto Sans CJK SC'), localFace, 'the historical English alias must stay compatible');
+assert.equal(findLocalFont('思源黑体'), localFace, 'the historical Chinese alias must stay compatible');
+assert.match(localFace.files[400] ?? '', /HarmonyOS_Sans_SC_Regular\.woff2$/);
+assert.match(localFace.files[700] ?? '', /HarmonyOS_Sans_SC_Bold\.woff2$/);
+assert.deepEqual(
+  Object.keys(localFace.files).map(Number).sort((a, b) => a - b),
+  [400, 700],
+  'the compatibility face must expose the bundled regular and bold variants',
+);
+
+const catalogEntries = FONT_CATALOG.filter((entry) => entry.family === 'Noto Sans SC');
+assert.equal(catalogEntries.length, 1, 'the font catalog must not expose duplicate remote and local entries');
+assert.equal(catalogEntries[0]?.source, 'bundled', 'the font picker must report the offline source truthfully');
+
+console.log('notoSansOffline.verify: Noto Sans SC exports use bundled CJK bytes');

--- a/src/i18n/dict/en/components.ts
+++ b/src/i18n/dict/en/components.ts
@@ -59,6 +59,7 @@ export default {
   '导出历史': 'Export History',
   '关闭': 'Close',
   '还没有导出记录': 'No exports yet',
+  '打开文件夹': 'Open Folder',
   '清空历史': 'Clear History',
 
   // ---- VersionHistory ----


### PR DESCRIPTION
## Summary
- bundle an offline CJK font path with the complete upstream font license
- raise and configure Remotion initialization timeout and cancel renders after client disconnects
- include motion graphics in editable-project exports by default
- add a grant-safe export-history action to reveal the generated file

## Verification
- npm test
- npm run build
- five focused export checks
- oxlint and git diff --check
- Impeccable detector: no findings
- Open Code Review: no High/Critical findings

## Notes
- remains Draft pending real Electron visual acceptance
- hosted sharing, Jianying-specific output, private paths, and branding are intentionally excluded