### PR TITLE
feat(captions): complete caption editing and timeline foundations

### DIFF
--- a/src/captions/CaptionPreviewEditor.tsx
+++ b/src/captions/CaptionPreviewEditor.tsx
@@ -4,7 +4,7 @@ import type { PlayerRef } from '@remotion/player';
 import type { TimelineState } from '../editor/types';
 import type { CaptionsData } from './types';
 import { CAPTION_STYLES } from './styles';
-import { containerStyle, wordStyle } from './renderStyles';
+import { captionPreviewTextColor, captionPreviewTextColorPatch, containerStyle, wordStyle } from './renderStyles';
 import { buildCues, fmtCueMs } from './captionCues';
 import {
   captionPreviewLayoutPatch,
@@ -14,6 +14,7 @@ import {
 } from './captionPreviewTarget';
 import { Icon } from '../components/icons';
 import { useT } from '../i18n/locale';
+import { captionTemplatePatch } from './captionTemplatePatch';
 
 // Preview the caption direct editing layer on the canvas: click on the screen caption → check box + floating toolbar (AI Edit/Style/Font Size).
 // Editor side overlay, no synthesis: geometry is recalculated by passing "display area px size" to containerStyle,
@@ -114,9 +115,10 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
   }
 
   const preset = target.preset;
+  const currentTextColor = captionPreviewTextColor(preset);
   const block = containerStyle(preset, captions.template, box.w, box.h, target.layout);
   const textCss = {
-    ...wordStyle(preset, false),
+    ...wordStyle(preset, !preset.wholeLine),
     background: preset.wholeLine && preset.background ? preset.background : 'transparent',
     borderRadius: 6,
     padding: preset.wholeLine && preset.background ? '0.1em 0.42em' : 0,
@@ -133,7 +135,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
     onUpdateCaptions(captionPreviewStylePatch(captions, target, { fontSize: next }));
   };
   const setColor = (hex: string) => {
-    onUpdateCaptions(captionPreviewStylePatch(captions, target, { color: hex }));
+    onUpdateCaptions(captionPreviewStylePatch(captions, target, captionPreviewTextColorPatch(preset, hex)));
   };
   // ── Drag and move (bottom anchor offsetYRatio positive upward, containerStyle takes the negative sign) ──
   const anchorV = (() => {
@@ -189,7 +191,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
     setDrag(null);
   };
 
-  const curColor = preset.color;
+  const curColor = currentTextColor;
 
   return (
     <div ref={rootRef} style={{ position: 'absolute', inset: 0, zIndex: 4, pointerEvents: 'none', overflow: 'visible' }}>
@@ -206,7 +208,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
                 if (e.key === 'Escape') { e.stopPropagation(); setEditing(false); }
               }}
               style={{
-                ...textCss, background: '#000000d9', color: preset.color, font: 'inherit', fontSize: 'inherit',
+                ...textCss, background: '#000000d9', color: currentTextColor, font: 'inherit', fontSize: 'inherit',
                 width: 'max(220px, 100%)', textAlign: 'center', border: '1.5px solid var(--cc-accent)',
                 outline: 'none', resize: 'none', lineHeight: 1.25,
               }}
@@ -264,7 +266,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
                   {CAPTION_STYLES.map((st) => (
                     <button key={st.id} type="button"
                       className={`cc-capedit-styleitem${st.id === captions.template ? ' on' : ''}`}
-                      onClick={() => { onUpdateCaptions({ template: st.id }); setPop(null); }}>
+                      onClick={() => { onUpdateCaptions(captionTemplatePatch(captions, st.id)); setPop(null); }}>
                       {t(st.labelZh)}
                     </button>
                   ))}

--- a/src/captions/CaptionPreviewEditor.tsx
+++ b/src/captions/CaptionPreviewEditor.tsx
@@ -8,9 +8,11 @@ import { captionPreviewTextColor, captionPreviewTextColorPatch, containerStyle, 
 import { buildCues, fmtCueMs } from './captionCues';
 import {
   captionPreviewLayoutPatch,
+  captionPreviewNudgePatch,
   captionPreviewStylePatch,
   captionPreviewTextPatch,
   findCaptionPreviewTarget,
+  type CaptionPreviewNudgeDirection,
 } from './captionPreviewTarget';
 import { Icon } from '../components/icons';
 import { useT } from '../i18n/locale';
@@ -36,6 +38,12 @@ interface CaptionPreviewEditorProps {
 const FONT_STEP = 1.12;
 const clampFont = (v: number): number => Math.min(0.14, Math.max(0.02, v));
 const DRAG_THRESHOLD = 4;
+const ARROW_NUDGE_DIRECTION: Partial<Record<string, CaptionPreviewNudgeDirection>> = {
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  ArrowUp: 'up',
+  ArrowDown: 'down',
+};
 /** Text color quick color palette (white/black + common accent colors) */
 const COLOR_SWATCHES = ['#ffffff', '#0a0a0a', '#FFD84A', '#FF5A5A', '#6EE7F9', '#7CFF9B', '#FF8FD1', '#FFA94D'];
 
@@ -150,6 +158,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
     // frames; waiting for pointerup allowed the active cue to change first.
     setSelected(true);
     playerRef.current?.pause();
+    (e.currentTarget as HTMLElement).focus({ preventScroll: true });
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
     dragRef.current = {
       startX: e.clientX, startY: e.clientY,
@@ -190,6 +199,15 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
     }
     setDrag(null);
   };
+  const onHitKeyDown = (e: React.KeyboardEvent) => {
+    if (!selected || editing || e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) return;
+    const direction = ARROW_NUDGE_DIRECTION[e.key];
+    if (!direction) return;
+    e.preventDefault();
+    e.stopPropagation();
+    playerRef.current?.pause();
+    onUpdateCaptions(captionPreviewNudgePatch(captions, target, direction));
+  };
 
   const curColor = currentTextColor;
 
@@ -218,10 +236,12 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
             <div
               className="cc-capedit-hit"
               role="button"
+              tabIndex={0}
               title={t('点击选中字幕；拖动移动位置；双击直接改文字')}
               onPointerDown={onHitPointerDown}
               onPointerMove={onHitPointerMove}
               onPointerUp={onHitPointerUp}
+              onKeyDown={onHitKeyDown}
               onDoubleClick={() => { setSelected(true); setEditing(true); setDraft(cue.text); playerRef.current?.pause(); }}
               style={drag
                 ? { ...textCss, opacity: 0.92, cursor: 'grabbing', touchAction: 'none', userSelect: 'none' }

--- a/src/captions/CaptionPreviewEditor.tsx
+++ b/src/captions/CaptionPreviewEditor.tsx
@@ -111,7 +111,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
     onAutoEditHandled?.();
   }, [autoEditLaneId, cue, onAutoEditHandled, playerRef, target]);
   useEffect(() => {
-    if (!selected || (!editing && pop === null)) return;
+    if (!selected) return;
     const onDown = (event: PointerEvent) => {
       const node = event.target instanceof Node ? event.target : null;
       const action = captionPreviewOutsideClickAction({

--- a/src/captions/CaptionPreviewEditor.tsx
+++ b/src/captions/CaptionPreviewEditor.tsx
@@ -17,6 +17,7 @@ import {
 import { Icon } from '../components/icons';
 import { useT } from '../i18n/locale';
 import { captionTemplatePatch } from './captionTemplatePatch';
+import { captionPreviewOutsideClickAction } from './captionPreviewToolbar';
 
 // Preview the caption direct editing layer on the canvas: click on the screen caption → check box + floating toolbar (AI Edit/Style/Font Size).
 // Editor side overlay, no synthesis: geometry is recalculated by passing "display area px size" to containerStyle,
@@ -57,6 +58,8 @@ interface DragRef {
 export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCaptions, onSeedChat, autoEditLaneId, onAutoEditHandled }: CaptionPreviewEditorProps) {
   const t = useT();
   const rootRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<HTMLTextAreaElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
   const [box, setBox] = useState<{ w: number; h: number } | null>(null);
   const [frame, setFrame] = useState(0);
   const [selected, setSelected] = useState(false);
@@ -108,15 +111,31 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
     onAutoEditHandled?.();
   }, [autoEditLaneId, cue, onAutoEditHandled, playerRef, target]);
   useEffect(() => {
-    if (!selected) return;
-    const onDown = (e: PointerEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        setSelected(false); setEditing(false); setPop(null);
+    if (!selected || (!editing && pop === null)) return;
+    const onDown = (event: PointerEvent) => {
+      const node = event.target instanceof Node ? event.target : null;
+      const action = captionPreviewOutsideClickAction({
+        editing,
+        popoverOpen: pop !== null,
+        insideEditor: Boolean(node && editorRef.current?.contains(node)),
+        insideToolbar: Boolean(node && toolbarRef.current?.contains(node)),
+        draftChanged: Boolean(target && draft !== target.cue.text),
+      });
+      if (action.commitDraft && target) {
+        const patch = captionPreviewTextPatch(captions, target, draft);
+        if (patch) onUpdateCaptions(patch);
+      }
+      if (action.closeEditor) setEditing(false);
+      if (action.closePopover) setPop(null);
+      if (node && rootRef.current && !rootRef.current.contains(node)) {
+        setSelected(false);
+        setEditing(false);
+        setPop(null);
       }
     };
     window.addEventListener('pointerdown', onDown, true);
     return () => window.removeEventListener('pointerdown', onDown, true);
-  }, [selected]);
+  }, [captions, draft, editing, onUpdateCaptions, pop, selected, target]);
 
   if (!target || !cue || !box) {
     return <div ref={rootRef} style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }} />;
@@ -217,6 +236,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
         <div style={{ position: 'relative', pointerEvents: 'auto', maxWidth: '100%', transform: drag ? `translate(${drag.dx}px, ${drag.dy}px)` : undefined }}>
           {editing ? (
             <textarea
+              ref={editorRef}
               value={draft}
               autoFocus
               rows={2}
@@ -242,7 +262,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
               onPointerMove={onHitPointerMove}
               onPointerUp={onHitPointerUp}
               onKeyDown={onHitKeyDown}
-              onDoubleClick={() => { setSelected(true); setEditing(true); setDraft(cue.text); playerRef.current?.pause(); }}
+              onDoubleClick={() => { setSelected(true); setPop(null); setEditing(true); setDraft(cue.text); playerRef.current?.pause(); }}
               style={drag
                 ? { ...textCss, opacity: 0.92, cursor: 'grabbing', touchAction: 'none', userSelect: 'none' }
                 : { ...textCss, color: 'transparent', WebkitTextStroke: undefined, textShadow: 'none', background: 'transparent', cursor: 'grab', touchAction: 'none', userSelect: 'none' }}
@@ -256,7 +276,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
 
           {/* Floating toolbar (AI editing | text/style/color | font size | delete)*/}
           {selected && !drag && (
-            <div className="cc-capedit-bar" onPointerDown={(e) => e.stopPropagation()}>
+            <div ref={toolbarRef} className="cc-capedit-bar" onPointerDown={(e) => e.stopPropagation()}>
               {onSeedChat && (
                 <>
                   <button type="button" className="cc-capedit-btn ai" title={t('让 AI 改写这句')}
@@ -266,7 +286,13 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
                   <span className="cc-capedit-divider" aria-hidden />
                 </>
               )}
-              <button type="button" className="cc-capedit-btn" title={t('编辑文字')} onClick={() => { setEditing(true); setDraft(cue.text); }}>
+              <button type="button" className="cc-capedit-btn" title={t('编辑文字')} onClick={() => {
+                setPop(null);
+                if (!editing) {
+                  setEditing(true);
+                  setDraft(cue.text);
+                }
+              }}>
                 <Icon name="pencil" size={12} />{t('文字')}
               </button>
               <button type="button" className={`cc-capedit-btn${pop === 'styles' ? ' on' : ''}`} title={t('字幕样式')} onClick={() => setPop(pop === 'styles' ? null : 'styles')}>Aa</button>

--- a/src/captions/CaptionPreviewEditor.tsx
+++ b/src/captions/CaptionPreviewEditor.tsx
@@ -4,7 +4,7 @@ import type { PlayerRef } from '@remotion/player';
 import type { TimelineState } from '../editor/types';
 import type { CaptionsData } from './types';
 import { CAPTION_STYLES } from './styles';
-import { captionPreviewTextColor, captionPreviewTextColorPatch, containerStyle, wordStyle } from './renderStyles';
+import { captionBoxStyle, captionPreviewTextColor, captionPreviewTextColorPatch, containerStyle, wordStyle } from './renderStyles';
 import { buildCues, fmtCueMs } from './captionCues';
 import {
   captionPreviewLayoutPatch,
@@ -146,9 +146,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
   const block = containerStyle(preset, captions.template, box.w, box.h, target.layout);
   const textCss = {
     ...wordStyle(preset, !preset.wholeLine),
-    background: preset.wholeLine && preset.background ? preset.background : 'transparent',
-    borderRadius: 6,
-    padding: preset.wholeLine && preset.background ? '0.1em 0.42em' : 0,
+    ...captionBoxStyle(preset, !preset.wholeLine, Boolean(preset.wholeLine)),
     whiteSpace: 'pre-wrap' as const,
   };
 
@@ -206,6 +204,7 @@ export function CaptionPreviewEditor({ state, captions, playerRef, onUpdateCapti
       const dx = e.clientX - d.startX;
       const dy = e.clientY - d.startY;
       onUpdateCaptions(captionPreviewLayoutPatch(captions, target, {
+          ...target.layout,
           anchor: target.layout?.anchor ?? 'bottom-center',
           offsetXRatio: d.baseX + dx / box.w,
           offsetYRatio: d.baseY + d.ySign * (dy / box.h),

--- a/src/captions/CaptionStyleMenu.tsx
+++ b/src/captions/CaptionStyleMenu.tsx
@@ -12,6 +12,7 @@ import type { EditorCommands } from '../editor/store';
 import { useT } from '../i18n/locale';
 import { captionsForTrack } from './captionTrack';
 import { newManualCaptions } from './manualCaptions';
+import { captionTemplatePatch } from './captionTemplatePatch';
 
 const CAPTION_LANGS = ['English', '日本語', '한국어', 'Español', 'Français', 'Deutsch', 'Português'];
 
@@ -38,8 +39,9 @@ export function CaptionStyleMenu({ state, commands, trackId, pos, error, onError
 
   const applyStyle = (template: CaptionTemplate) => {
     const captions = captionsForTrack(state, trackId) ?? newManualCaptions();
-    if (current) commands.updateCaptions({ enabled: true, template }, trackId);
-    else commands.setCaptions({ ...captions, template }, trackId);
+    const patch = { enabled: true, ...captionTemplatePatch(captions, template) };
+    if (current) commands.updateCaptions(patch, trackId);
+    else commands.setCaptions({ ...captions, ...patch }, trackId);
     onError(null);
     onClose();
   };
@@ -77,9 +79,8 @@ export function CaptionStyleMenu({ state, commands, trackId, pos, error, onError
     const captions = captionsForTrack(state, trackId) ?? newManualCaptions();
     const patch: Partial<CaptionsData> = {
       enabled: true,
-      ...(preset.template ? { template: preset.template } : {}),
+      ...captionTemplatePatch(captions, preset.template ?? captions.template, preset.styleOverride),
       ...(preset.pacing ? { pacing: preset.pacing } : {}),
-      ...(preset.styleOverride ? { styleOverride: preset.styleOverride } : {}),
     };
     if (current) commands.updateCaptions(patch, trackId);
     else commands.setCaptions({ ...captions, ...patch }, trackId);

--- a/src/captions/CaptionTrackLane.tsx
+++ b/src/captions/CaptionTrackLane.tsx
@@ -15,6 +15,22 @@ import {
   resizedManualCueTiming,
   type ManualCueEdge,
 } from './manualCaptions';
+import { findCaptionPreviewTarget } from './captionPreviewTarget';
+import {
+  captionSelectionKey,
+  captionSelectionRef,
+  resolveCaptionSelection,
+  type CaptionSelectOptions,
+  type CaptionSelectionRef,
+} from './captionSelection';
+import { captionContextMenuIntent, updateCaptionSelections } from './captionSelectionInteraction';
+import { CAPTION_CUE_TRANSLATION_LANGS, captionCueAgentSeed, captionCueText } from './captionCueMenu';
+import {
+  appendCaptionClipboardToTrack,
+  createCaptionTimelineClipboard,
+  type CaptionTimelineClipboard,
+} from './captionTimelineClipboard';
+import { translateLines } from './translate';
 
 const SNAP_PX = 8;
 
@@ -190,12 +206,14 @@ function useCaptionMove(options: {
   return { drag, start, cancel: () => updateDrag(null) };
 }
 
-function CaptionCueBlock({ page, index, target, locked, selected, px, fps, moveOffsetY, trim, move, onSelect, onDelete, onMenu }: {
-  page: CaptionPage; index: number; target?: ManualCueTarget; locked: boolean; selected: boolean; px: number; fps: number;
+function CaptionCueBlock({ page, index, target, selectionRef, locked, selected, px, fps, moveOffsetY, trim, move, onSelect, onDelete, onMenu }: {
+  page: CaptionPage; index: number; target?: ManualCueTarget; selectionRef: CaptionSelectionRef | null;
+  locked: boolean; selected: boolean; px: number; fps: number;
   moveOffsetY: number;
   trim: ReturnType<typeof useCaptionTrim>; move: ReturnType<typeof useCaptionMove>;
-  onSelect: (key: string | null) => void; onDelete: (target: ManualCueTarget) => void;
-  onMenu: (event: ReactMouseEvent, target: ManualCueTarget) => void;
+  onSelect: (selection: CaptionSelectionRef | null, options?: CaptionSelectOptions) => void;
+  onDelete: (target: ManualCueTarget) => void;
+  onMenu: (event: ReactMouseEvent, target: ManualCueTarget, selection: CaptionSelectionRef) => void;
 }) {
   const t = useT();
   const key = target ? `${target.laneId}:${target.index}` : `${page.start}:${index}`;
@@ -225,13 +243,29 @@ function CaptionCueBlock({ page, index, target, locked, selected, px, fps, moveO
     }}
   /> : null;
   return (
-    <div className={`cc-caption-track-cue${selected ? ' selected' : ''}`} title={text} tabIndex={target && !locked ? 0 : undefined}
+    <div className={`cc-caption-track-cue${selected ? ' selected' : ''}`} data-caption-selection-owner="timeline-cue"
+      title={text} tabIndex={selectionRef && !locked ? 0 : undefined}
       style={{ left: startFrame * px, width: Math.max(18, durationFrames * px),
         transform: move.drag?.key === key && moveOffsetY ? `translate3d(0, ${moveOffsetY}px, 0)` : undefined,
         zIndex: move.drag?.key === key ? 10 : undefined }}
-      onPointerDown={(event) => { if (!target) return; onSelect(key); event.currentTarget.focus(); move.start(event, key, target); }}
+      onPointerDown={(event) => {
+        if (!selectionRef || locked) return;
+        const additive = event.metaKey || event.ctrlKey;
+        onSelect(selectionRef, additive
+          ? { additive: true, preserveWithItems: true, toggle: true }
+          : undefined);
+        event.currentTarget.focus();
+        if (target && !additive) move.start(event, key, target);
+      }}
       onPointerCancel={move.cancel}
-      onContextMenu={(event) => { if (!target || locked) return; event.preventDefault(); onSelect(key); onMenu(event, target); }}
+      onContextMenu={(event) => {
+        if (!target || locked || !selectionRef) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (captionContextMenuIntent(event.ctrlKey) === 'ignore-after-toggle') return;
+        if (!selected) onSelect(selectionRef);
+        onMenu(event, target, selectionRef);
+      }}
       onKeyDown={(event) => {
         if (!target || (event.key !== 'Delete' && event.key !== 'Backspace')) return;
         event.preventDefault();
@@ -242,20 +276,60 @@ function CaptionCueBlock({ page, index, target, locked, selected, px, fps, moveO
   );
 }
 
-export function CaptionTrackLane({ state, captions, trackId, playheadFrame, px, rowHeight, hidden, locked, snapping, trackFromClientY, onUpdate, onMove, onDelete }: {
+export function CaptionTrackLane({
+  state, captions, trackId, playheadFrame, px, rowHeight, hidden, locked, snapping, trackFromClientY,
+  selectedCaptions: controlledSelectedCaptions, onSelectCaption, onUpdate, onMove, onDelete,
+  onCopyCue, onPasteCue, onSeedChat, onTranslateCue,
+}: {
   state: TimelineState; captions: CaptionsData | null; trackId: TrackId; playheadFrame: number; px: number;
   hidden: boolean; locked: boolean; snapping: boolean; rowHeight: number; trackFromClientY: (clientY: number) => TrackId;
+  selectedCaptions?: CaptionSelectionRef[];
+  onSelectCaption?: (selection: CaptionSelectionRef | null, options?: CaptionSelectOptions) => void;
   onUpdate: (patch: Partial<CaptionsData>) => void; onMove: (move: CaptionCueMove) => void;
   onDelete: (laneId: string, index: number) => void;
+  onCopyCue?: (selection: CaptionSelectionRef) => void;
+  onPasteCue?: () => boolean;
+  onSeedChat?: (text: string) => void;
+  onTranslateCue?: (text: string, start: number, end: number) => void;
 }) {
   const t = useT();
-  const [selected, setSelected] = useState<string | null>(null);
-  const [menu, setMenu] = useState<{ x: number; y: number; target: ManualCueTarget } | null>(null);
+  const [localSelections, setLocalSelections] = useState<CaptionSelectionRef[]>([]);
+  const selectedCaptions = controlledSelectedCaptions ?? localSelections;
+  const selectCaption = (selection: CaptionSelectionRef | null, options?: CaptionSelectOptions) => {
+    if (onSelectCaption) {
+      onSelectCaption(selection, options);
+      return;
+    }
+    if (!selection) {
+      setLocalSelections([]);
+      return;
+    }
+    if (!options?.additive) {
+      setLocalSelections([selection]);
+      return;
+    }
+    setLocalSelections((current) => updateCaptionSelections(current, selection, options.toggle ? 'toggle' : 'add'));
+  };
+  const [timelineClipboard, setTimelineClipboard] = useState<CaptionTimelineClipboard | null>(null);
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    target: ManualCueTarget;
+    selection: CaptionSelectionRef;
+  } | null>(null);
+  const [translationOpen, setTranslationOpen] = useState(false);
+  const [menuBusy, setMenuBusy] = useState(false);
+  const [menuError, setMenuError] = useState<string | null>(null);
+  const closeMenu = () => {
+    setMenu(null);
+    setTranslationOpen(false);
+    setMenuBusy(false);
+    setMenuError(null);
+  };
   useEffect(() => {
     if (!menu) return;
-    const close = () => setMenu(null);
-    window.addEventListener('pointerdown', close);
-    return () => window.removeEventListener('pointerdown', close);
+    window.addEventListener('pointerdown', closeMenu);
+    return () => window.removeEventListener('pointerdown', closeMenu);
   }, [menu]);
   const pages = captions ? captionPages(captions, state.items, state.fps) : [];
   const targets = manualCueTargets(captions);
@@ -267,9 +341,72 @@ export function CaptionTrackLane({ state, captions, trackId, playheadFrame, px, 
     && !state.tracks?.[move.drag.targetTrackId]?.locked
     ? (trackIds.indexOf(move.drag.targetTrackId) - trackIds.indexOf(trackId)) * rowHeight
     : 0;
-  const remove = (target: ManualCueTarget) => { setSelected(null); setMenu(null); onDelete(target.laneId, target.index); };
+  const remove = (target: ManualCueTarget) => {
+    selectCaption(null);
+    closeMenu();
+    onDelete(target.laneId, target.index);
+  };
+  const copyCue = async (selection: CaptionSelectionRef) => {
+    const selectionIsActive = selectedCaptions.some(
+      (candidate) => captionSelectionKey(candidate) === captionSelectionKey(selection),
+    );
+    const selections = selectionIsActive ? selectedCaptions : [selection];
+    const cues = selections.flatMap((candidate) => {
+      const resolved = resolveCaptionSelection(state, candidate)?.target.cue;
+      return resolved ? [{ text: resolved.text, start: resolved.start, end: resolved.end }] : [];
+    });
+    const clipboard = createCaptionTimelineClipboard(cues);
+    if (!clipboard) return;
+    setTimelineClipboard(clipboard);
+    onCopyCue?.(selection);
+    try {
+      await navigator.clipboard.writeText(clipboard.cues.map((cue) => cue.text).join('\n'));
+    } catch {
+      // The structured in-app clipboard remains available when OS permission is denied.
+    }
+    closeMenu();
+  };
+  const pasteCue = () => {
+    if (onPasteCue?.()) {
+      closeMenu();
+      return;
+    }
+    if (!captions || !timelineClipboard) {
+      setMenuError(t('剪贴板里没有可粘贴的文字'));
+      return;
+    }
+    const patch = appendCaptionClipboardToTrack(
+      captions,
+      state.items,
+      timelineClipboard,
+      Math.round(playheadFrame * 1000 / state.fps),
+    );
+    if (!patch) {
+      setMenuError(t('剪贴板里没有可粘贴的文字'));
+      return;
+    }
+    onUpdate(patch);
+    closeMenu();
+  };
+  const translateCue = async (target: ManualCueTarget, language: string) => {
+    if (!onTranslateCue || menuBusy) return;
+    const cue = target.words[target.index];
+    if (!cue) return;
+    setMenuBusy(true);
+    setMenuError(null);
+    try {
+      const [translated] = await translateLines([captionCueText(target)], language);
+      const text = translated?.trim();
+      if (!text) throw new Error(t('字幕翻译没有返回文字'));
+      onTranslateCue(text, cue.start, cue.end);
+      closeMenu();
+    } catch (cause) {
+      setMenuBusy(false);
+      setMenuError(cause instanceof Error ? cause.message : t('字幕翻译失败'));
+    }
+  };
   return (
-    <div className="cc-caption-track-lane" style={{
+    <div className="cc-caption-track-lane" data-caption-selection-region="timeline" style={{
       background: locked ? `color-mix(in srgb, ${theme.bg} 70%, ${themeAlpha.shadow(1)})` : theme.bg,
       opacity: hidden ? 0.4 : locked ? 0.75 : 1,
       overflow: move.drag ? 'visible' : undefined,
@@ -279,12 +416,50 @@ export function CaptionTrackLane({ state, captions, trackId, playheadFrame, px, 
       {pages.map((page, index) => {
         const target = page.words.length === 1 ? targets.get(page.words[0]!) : undefined;
         const key = target ? `${target.laneId}:${target.index}` : `${page.start}:${index}`;
-        return <CaptionCueBlock key={key} page={page} index={index} target={target} locked={locked} selected={selected === key}
-          px={px} fps={state.fps} moveOffsetY={moveOffsetY} trim={trim} move={move} onSelect={setSelected} onDelete={remove}
-          onMenu={(event, cue) => setMenu({ x: event.clientX, y: event.clientY, target: cue })} />;
+        const previewTarget = !target && captions
+          ? findCaptionPreviewTarget(captions, state.items, state.fps, (page.start + page.end) / 2)
+          : null;
+        const selectionRef = target
+          ? { trackId, kind: 'manual' as const, laneId: target.laneId, cueIndex: target.index }
+          : previewTarget ? captionSelectionRef(trackId, previewTarget) : null;
+        const selected = selectedCaptions.some(
+          (selection) => captionSelectionKey(selection) === captionSelectionKey(selectionRef),
+        );
+        return <CaptionCueBlock key={key} page={page} index={index} target={target} selectionRef={selectionRef}
+          locked={locked} selected={selected} px={px} fps={state.fps} moveOffsetY={moveOffsetY}
+          trim={trim} move={move} onSelect={selectCaption} onDelete={remove}
+          onMenu={(event, cue, selection) => {
+            setTranslationOpen(false);
+            setMenuError(null);
+            setMenu({
+              x: Math.max(8, Math.min(event.clientX, window.innerWidth - 180)),
+              y: Math.max(8, Math.min(event.clientY, window.innerHeight - 300)),
+              target: cue,
+              selection,
+            });
+          }} />;
       })}
-      {menu && <div className="cc-caption-cue-menu" role="menu" style={{ left: menu.x, top: menu.y }} onPointerDown={(event) => event.stopPropagation()}>
-        <button type="button" role="menuitem" onClick={() => remove(menu.target)}>{t('删除')}</button>
+      {menu && <div className="cc-caption-cue-menu" data-caption-selection-owner="cue-menu" role="menu"
+        style={{ left: menu.x, top: menu.y }} onPointerDown={(event) => event.stopPropagation()}>
+        {translationOpen ? <>
+          <button type="button" role="menuitem" onClick={() => setTranslationOpen(false)}>{t('翻译')}</button>
+          {CAPTION_CUE_TRANSLATION_LANGS.map((language) => <button key={language.label} type="button" role="menuitem"
+            disabled={menuBusy} onClick={() => void translateCue(menu.target, language.label)}>
+            {language.flag} {language.label}
+          </button>)}
+        </> : <>
+          <button type="button" role="menuitem" onClick={() => void copyCue(menu.selection)}>{t('复制')}</button>
+          <button type="button" role="menuitem" onClick={pasteCue}>{t('粘贴')}</button>
+          {onTranslateCue && <button type="button" role="menuitem" aria-haspopup="menu"
+            onClick={() => setTranslationOpen(true)}>{t('翻译')} ›</button>}
+          {onSeedChat && <button type="button" role="menuitem" onClick={() => {
+            onSeedChat(captionCueAgentSeed(captionCueText(menu.target)));
+            closeMenu();
+          }}>{t('添加到 AI 对话框')}</button>}
+          <button type="button" role="menuitem" onClick={() => remove(menu.target)}>{t('删除')}</button>
+        </>}
+        {menuBusy && <div role="status">{t('翻译中...')}</div>}
+        {menuError && <div role="alert">{menuError}</div>}
       </div>}
     </div>
   );

--- a/src/captions/CaptionsControls.tsx
+++ b/src/captions/CaptionsControls.tsx
@@ -8,6 +8,7 @@ import { theme } from '../theme';
 import { useT } from '../i18n/locale';
 import { ManualCaptionEditor } from './ManualCaptionEditor';
 import { beginCaptionStylePointerDrag } from './captionStyleDrag';
+import { captionTemplatePatch } from './captionTemplatePatch';
 
 interface CaptionsControlsProps {
   captionTrackId?: TrackId;
@@ -123,7 +124,7 @@ export function CaptionsControls({
                     aria-selected={active}
                     className={`cc-cap-style${active ? ' selected' : ''}`}
                     title={`${t(s.labelZh)} — ${t(s.hint)} · ${t('拖到预览画面任意位置新建字幕')}`}
-                    onClick={() => onUpdate({ template: s.id as CaptionTemplate })}
+                    onClick={() => onUpdate(captionTemplatePatch(captions, s.id as CaptionTemplate))}
                     onPointerDown={(event) => {
                       if (!captionTrackId) return;
                       beginCaptionStylePointerDrag(event.nativeEvent, { trackId: captionTrackId, template: s.id });

--- a/src/captions/CaptionsLayer.tsx
+++ b/src/captions/CaptionsLayer.tsx
@@ -6,7 +6,7 @@ import { paginate, activePage, currentWordIndex, activeTranslation, joinCaptionW
 import type { TimelineItem } from '../editor/types';
 import { buildLaneGroups, type LanePage } from './lanes';
 import { resolveCaptionWords, resolveCaptionWordIndices, applyWordOverrides } from './resolve';
-import { containerStyle, effectivePreset, wordStyle } from './renderStyles';
+import { captionBoxStyle, containerStyle, effectivePreset, wordStyle } from './renderStyles';
 
 const CAPTION_OVERLAY_STYLE = { pointerEvents: 'none', zIndex: 1 } as const;
 
@@ -42,13 +42,13 @@ function SingleStreamCaptions({ captions, items, ms, width, height, fps }: { cap
       <div style={containerStyle(preset, captions.template, width, height, captions.layout)}>
         {preset.wholeLine ? (
           // The entire sentence is continuous: one text per page (no word gaps, no word-by-word highlighting), and the background covers the entire line (classic black captions).
-          <div style={{ ...wordStyle(preset, false), background: preset.background ?? 'transparent', borderRadius: 6, padding: preset.background ? '0.1em 0.42em' : 0, whiteSpace: 'pre-wrap' }}>
+          <div style={{ ...wordStyle(preset, false), ...captionBoxStyle(preset, false, true), whiteSpace: 'pre-wrap' }}>
             {joinCaptionWords(page.words)}
           </div>
         ) : (
           <div style={{ display: 'flex', flexDirection: preset.displayMode === 'stacked' ? 'column' : 'row', flexWrap: 'wrap', justifyContent: 'center', gap: '0.2em' }}>
             {page.words.map((w, i) => (
-              <span key={i} style={{ position: 'relative', ...wordStyle(preset, i === curIdx) }}>{w.text}</span>
+              <span key={i} style={{ position: 'relative', ...wordStyle(preset, i === curIdx), ...captionBoxStyle(preset, i === curIdx) }}>{w.text}</span>
             ))}
           </div>
         )}
@@ -81,7 +81,14 @@ function MultiLaneCaptions({ captions, items, ms, width, height }: { captions: C
     <AbsoluteFill style={CAPTION_OVERLAY_STYLE}>
       {groups.map((g, gi) => {
         const layout: CaptionLayout | undefined = g.anchor
-          ? { anchor: g.anchor, offsetXRatio: g.offsetXRatio, offsetYRatio: g.offsetYRatio }
+          ? {
+              anchor: g.anchor,
+              offsetXRatio: g.offsetXRatio,
+              offsetYRatio: g.offsetYRatio,
+              scale: g.scale,
+              rotation: g.rotation,
+              opacity: g.opacity,
+            }
           : captions.layout;
         return (
           <div key={gi} style={containerStyle(basePreset, captions.template, width, height, layout)}>
@@ -105,7 +112,7 @@ function LaneCaption({ lane, basePreset, height }: { lane: LanePage; basePreset:
   } as const;
   if (preset.wholeLine) {
     return (
-      <div style={{ ...typography, ...wordStyle(preset, false), background: preset.background ?? 'transparent', borderRadius: 6, padding: preset.background ? '0.1em 0.42em' : 0, whiteSpace: 'pre-wrap' }}>
+      <div style={{ ...typography, ...wordStyle(preset, false), ...captionBoxStyle(preset, false, true), whiteSpace: 'pre-wrap' }}>
         {joinCaptionWords(lane.page.words)}
       </div>
     );
@@ -113,7 +120,7 @@ function LaneCaption({ lane, basePreset, height }: { lane: LanePage; basePreset:
   return (
     <div style={{ ...typography, display: 'flex', flexDirection: preset.displayMode === 'stacked' ? 'column' : 'row', flexWrap: 'wrap', justifyContent: 'center', gap: '0.2em' }}>
       {lane.page.words.map((word, index) => (
-        <span key={index} style={{ position: 'relative', ...wordStyle(preset, index === lane.curIdx) }}>{word.text}</span>
+        <span key={index} style={{ position: 'relative', ...wordStyle(preset, index === lane.curIdx), ...captionBoxStyle(preset, index === lane.curIdx) }}>{word.text}</span>
       ))}
     </div>
   );

--- a/src/captions/captionCueContextMenu.verify.ts
+++ b/src/captions/captionCueContextMenu.verify.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('./CaptionTrackLane.tsx', import.meta.url), 'utf8');
+
+assert.match(source, /role="menu"/, 'caption cue context actions should use menu semantics');
+assert.match(source, /createCaptionTimelineClipboard/, 'copy should capture structured cue timing, not only DOM text');
+assert.match(source, /appendCaptionClipboardToTrack/, 'paste should materialize copied cues at the playhead');
+assert.match(source, /captionContextMenuIntent\(event\.ctrlKey\)/, 'macOS Ctrl+click should not open a menu after toggling selection');
+assert.match(source, /onSeedChat\?/, 'caption context menu should support explicit AI handoff when the parent provides it');
+assert.doesNotMatch(source, /navigator\.clipboard\.readText\(/, 'timeline paste must not replace cue text from an unstructured clipboard read');
+
+console.log('captionCueContextMenu.verify: cue context-menu integration contract OK');

--- a/src/captions/captionCueMenu.ts
+++ b/src/captions/captionCueMenu.ts
@@ -1,0 +1,38 @@
+import type { TranscriptWord } from '../transcript/types';
+import type { CaptionsData } from './types';
+import { updateManualCue } from './manualCaptions';
+
+export const CAPTION_CUE_TRANSLATION_LANGS = [
+  { label: 'English', flag: '🇺🇸' },
+  { label: '日本語', flag: '🇯🇵' },
+  { label: '한국어', flag: '🇰🇷' },
+  { label: 'Español', flag: '🇪🇸' },
+  { label: 'Français', flag: '🇫🇷' },
+  { label: 'Deutsch', flag: '🇩🇪' },
+  { label: 'Português', flag: '🇵🇹' },
+] as const;
+
+export interface CaptionCueTextTarget {
+  laneId: string;
+  index: number;
+  words: readonly TranscriptWord[];
+}
+
+export function captionCueText(target: CaptionCueTextTarget): string {
+  return target.words[target.index]?.text.trim() ?? '';
+}
+
+export function replaceCaptionCueText(
+  captions: CaptionsData,
+  target: CaptionCueTextTarget,
+  text: string,
+): Partial<CaptionsData> | null {
+  const cue = target.words[target.index];
+  const clean = text.trim();
+  if (!cue || !clean) return null;
+  return updateManualCue(captions, target.laneId, target.index, clean, cue.start, cue.end);
+}
+
+export function captionCueAgentSeed(text: string): string {
+  return text.trim();
+}

--- a/src/captions/captionCueMenu.verify.ts
+++ b/src/captions/captionCueMenu.verify.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { appendManualCue, newManualCaptions } from './manualCaptions';
+
+const modulePath = './captionCueMenu';
+const { captionCueAgentSeed, captionCueText, replaceCaptionCueText } = await import(modulePath).catch(() => {
+  assert.fail('caption cue menu helpers must exist as a caption-owned data layer');
+});
+
+let captions = newManualCaptions();
+const laneId = captions.sourceEntries![0]!.id;
+captions = { ...captions, ...appendManualCue(captions, laneId, '  Original cue  ', 1_000, 2_000) };
+const words = captions.sourceEntries![0]!.words!;
+const target = { laneId, index: 0, words };
+
+assert.equal(captionCueText(target), 'Original cue', 'menu copy/AI actions should receive trimmed cue text');
+assert.equal(captionCueAgentSeed('  Improve this  '), 'Improve this', 'AI seed should be normalized');
+
+const patch = replaceCaptionCueText(captions, target, '  Replacement  ');
+assert.equal(patch?.sourceEntries?.[0]?.words?.[0]?.text, 'Replacement', 'editing a cue should preserve its timing and replace its text');
+assert.deepEqual(
+  patch?.sourceEntries?.[0]?.words?.[0],
+  { text: 'Replacement', start: 1_000, end: 2_000 },
+);
+assert.equal(replaceCaptionCueText(captions, target, '   '), null, 'blank replacement text must not destroy a cue');
+
+console.log('captionCueMenu.verify: caption cue menu data helpers OK');

--- a/src/captions/captionCues.ts
+++ b/src/captions/captionCues.ts
@@ -30,7 +30,15 @@ export function buildCues(captions: CaptionsData, items: TimelineItem[], fps: nu
     const override = overrides[indices[index] ?? -1];
     if (override?.hidden) continue;
     if (override?.forceBreak && visible.length > 0) breakBefore.add(visible.length);
-    const word = override?.text ? { ...words[index]!, text: override.text } : words[index]!;
+    const timingOffsetMs = override?.timingOffsetMs ?? 0;
+    const word = override?.text || timingOffsetMs
+      ? {
+          ...words[index]!,
+          ...(override?.text ? { text: override.text } : {}),
+          start: words[index]!.start + timingOffsetMs,
+          end: words[index]!.end + timingOffsetMs,
+        }
+      : words[index]!;
     visible.push({ text: word.text, src: indices[index] ?? -1 });
     visibleWords.push(word);
   }

--- a/src/captions/captionGroupMove.ts
+++ b/src/captions/captionGroupMove.ts
@@ -1,0 +1,296 @@
+import { moveItemsByDelta } from '../editor/multiSelect';
+import {
+  captionsOnTrack,
+  defaultTrackId,
+  type TimelineState,
+  type TrackId,
+} from '../editor/types';
+import type { CaptionsData, CaptionSourceEntry } from './types';
+import { isManualCaptionEntry } from './manualCaptions';
+import { captionSelectionKey, type CaptionSelectionRef } from './captionSelection';
+import { buildCues } from './captionCues';
+import { resolveEntryWords } from './resolve';
+import { orderedCaptionSourceEntries } from './sourceOrder';
+
+interface ManualCueLocation {
+  trackId: TrackId;
+  laneId: string;
+  cueIndex: number;
+  startMs: number;
+}
+
+interface AutomaticCueLocation {
+  trackId: TrackId;
+  startMs: number;
+  srcIdxs: number[];
+}
+
+export interface TimelineSelectionMovePreview {
+  itemIds: readonly string[];
+  captionSelections: readonly CaptionSelectionRef[];
+  deltaFrames: number;
+}
+
+export function captionSelectionMovePreviewUpdateMode(
+  preview: TimelineSelectionMovePreview | null,
+): 'sync' | 'batched' {
+  return preview ? 'sync' : 'batched';
+}
+
+export function selectionMovePreviewDeltaForItem(
+  itemId: string,
+  preview: TimelineSelectionMovePreview | null,
+): number {
+  return preview?.itemIds.includes(itemId) ? preview.deltaFrames : 0;
+}
+
+export function resolveCaptionDragSelection(
+  primary: CaptionSelectionRef,
+  captionSelections: readonly CaptionSelectionRef[],
+  itemIds: readonly string[],
+): { captionSelections: CaptionSelectionRef[]; itemIds: string[] } {
+  const primaryKey = captionSelectionKey(primary);
+  const insideSelection = captionSelections.some(
+    (selection) => captionSelectionKey(selection) === primaryKey,
+  );
+  return insideSelection
+    ? { captionSelections: [...captionSelections], itemIds: [...itemIds] }
+    : { captionSelections: [primary], itemIds: [] };
+}
+
+export function captionSelectionsForItemDrag(
+  itemWasSelected: boolean,
+  captionSelections: readonly CaptionSelectionRef[],
+): CaptionSelectionRef[] {
+  return itemWasSelected ? [...captionSelections] : [];
+}
+
+export function resolveItemDragSelection(
+  primaryItemId: string,
+  selectedItemIds: readonly string[],
+  captionSelections: readonly CaptionSelectionRef[],
+  options?: {
+    shiftKey: boolean;
+    anchorItemId: string | null;
+    items: TimelineState['items'];
+  },
+): { captionSelections: CaptionSelectionRef[]; itemIds: string[] } {
+  if (options?.shiftKey && options.anchorItemId) {
+    const anchor = options.items.find((item) => item.id === options.anchorItemId);
+    const target = options.items.find((item) => item.id === primaryItemId);
+    if (anchor && target && anchor.track === target.track) {
+      const lo = Math.min(anchor.startFrame, target.startFrame);
+      const hi = Math.max(anchor.startFrame, target.startFrame);
+      return {
+        captionSelections: [...captionSelections],
+        itemIds: options.items
+          .filter((item) => item.track === anchor.track && item.startFrame >= lo && item.startFrame <= hi)
+          .map((item) => item.id),
+      };
+    }
+  }
+  return selectedItemIds.includes(primaryItemId)
+    ? { captionSelections: [...captionSelections], itemIds: [...selectedItemIds] }
+    : { captionSelections: [], itemIds: [primaryItemId] };
+}
+
+function selectedManualCueLocations(
+  state: TimelineState,
+  selections: readonly CaptionSelectionRef[],
+): ManualCueLocation[] {
+  return selections.flatMap((selection) => {
+    if (selection.kind !== 'manual' || state.tracks?.[selection.trackId]?.locked) return [];
+    const captions = captionsOnTrack(state, selection.trackId);
+    const lane = captions?.sourceEntries?.find(
+      (entry) => entry.id === selection.laneId && isManualCaptionEntry(entry),
+    );
+    const cue = lane?.words?.[selection.cueIndex];
+    return cue ? [{
+      trackId: selection.trackId,
+      laneId: selection.laneId,
+      cueIndex: selection.cueIndex,
+      startMs: cue.start,
+    }] : [];
+  });
+}
+
+function selectedAutomaticCueLocations(
+  state: TimelineState,
+  selections: readonly CaptionSelectionRef[],
+): AutomaticCueLocation[] {
+  return selections.flatMap((selection) => {
+    if (selection.kind !== 'single' || state.tracks?.[selection.trackId]?.locked) return [];
+    const captions = captionsOnTrack(state, selection.trackId);
+    const cue = captions ? buildCues(captions, state.items, state.fps)[selection.cueIndex] : null;
+    return cue?.srcIdxs.length ? [{
+      trackId: selection.trackId,
+      startMs: cue.start,
+      srcIdxs: [...cue.srcIdxs],
+    }] : [];
+  });
+}
+
+function selectedCueIndexesByLane(locations: readonly ManualCueLocation[]): Map<string, Set<number>> {
+  const result = new Map<string, Set<number>>();
+  for (const location of locations) {
+    const key = `${location.trackId}\u0000${location.laneId}`;
+    const indexes = result.get(key) ?? new Set<number>();
+    indexes.add(location.cueIndex);
+    result.set(key, indexes);
+  }
+  return result;
+}
+
+function automaticCaptionSourceByOverrideIndex(
+  captions: CaptionsData,
+  state: TimelineState,
+): Map<number, string> {
+  if (captions.sourceEntries?.length) {
+    const words = orderedCaptionSourceEntries(captions.sourceEntries)
+      .filter((entry) => entry.visible !== false)
+      .flatMap((entry) => resolveEntryWords(entry, state.items, state.fps)
+        .map((word) => ({ word, itemId: entry.itemId })))
+      .sort((a, b) => a.word.start - b.word.start || a.word.end - b.word.end);
+    return new Map(words.map((word, index) => [index, word.itemId]));
+  }
+
+  if (captions.sourceItemId) {
+    const source = state.items.find((item) => item.id === captions.sourceItemId);
+    return new Map((source?.transcript ?? []).map((_, index) => [index, captions.sourceItemId!]));
+  }
+
+  let sourceItems: TimelineState['items'] = [];
+  if (captions.sourceMode === 'timeline') {
+    sourceItems = state.items
+      .filter((item) => item.transcript?.length)
+      .sort((a, b) => a.startFrame - b.startFrame || a.id.localeCompare(b.id));
+  } else if (captions.sources?.length) {
+    sourceItems = captions.sources
+      .map((id) => state.items.find((item) => item.id === id))
+      .filter((item): item is TimelineState['items'][number] => !!item?.transcript?.length);
+  }
+
+  const words = sourceItems
+    .flatMap((item) => resolveEntryWords(
+      { id: `source:${item.id}`, itemId: item.id },
+      state.items,
+      state.fps,
+    ).map((word) => ({ word, itemId: item.id })))
+    .sort((a, b) => a.word.start - b.word.start);
+  return new Map(words.map((word, index) => [index, word.itemId]));
+}
+
+/** Clamp a mixed selection with one shared delta at frame zero. */
+export function clampTimelineSelectionDelta(
+  state: TimelineState,
+  itemIds: readonly string[],
+  captionSelections: readonly CaptionSelectionRef[],
+  requestedDeltaFrames: number,
+): number {
+  const ids = new Set(itemIds);
+  const manualLocations = selectedManualCueLocations(state, captionSelections);
+  const automaticLocations = selectedAutomaticCueLocations(state, captionSelections);
+  let minDelta = Number.NEGATIVE_INFINITY;
+  let hasMovableSelection = false;
+
+  for (const item of state.items) {
+    if (!ids.has(item.id) || state.tracks?.[item.track]?.locked) continue;
+    hasMovableSelection = true;
+    minDelta = Math.max(minDelta, -item.startFrame);
+  }
+  for (const location of [...manualLocations, ...automaticLocations]) {
+    hasMovableSelection = true;
+    minDelta = Math.max(minDelta, Math.ceil(-location.startMs * state.fps / 1000));
+  }
+  return hasMovableSelection ? Math.max(minDelta, Math.round(requestedDeltaFrames)) : 0;
+}
+
+function moveAutomaticCaptionSelections(
+  state: TimelineState,
+  locations: readonly AutomaticCueLocation[],
+  itemIds: readonly string[],
+  deltaFrames: number,
+): TimelineState {
+  if (!locations.length || deltaFrames === 0) return state;
+  const deltaMs = Math.round(deltaFrames * 1000 / state.fps);
+  const selectedItemIds = new Set(itemIds);
+  let next = state;
+  for (const trackId of new Set(locations.map((location) => location.trackId))) {
+    const captions = captionsOnTrack(next, trackId);
+    if (!captions) continue;
+    const sourceByOverrideIndex = automaticCaptionSourceByOverrideIndex(captions, state);
+    const wordOverrides = { ...(captions.wordOverrides ?? {}) };
+    for (const location of locations) {
+      if (location.trackId !== trackId) continue;
+      for (const sourceIndex of location.srcIdxs) {
+        const sourceItemId = sourceByOverrideIndex.get(sourceIndex);
+        if (sourceItemId && selectedItemIds.has(sourceItemId)) continue;
+        const current = wordOverrides[sourceIndex] ?? {};
+        wordOverrides[sourceIndex] = {
+          ...current,
+          timingOffsetMs: (current.timingOffsetMs ?? 0) + deltaMs,
+        };
+      }
+    }
+    next = withCaptionTrack(next, trackId, { ...captions, wordOverrides });
+  }
+  return next;
+}
+
+function moveManualCaptionSelections(
+  state: TimelineState,
+  locations: readonly ManualCueLocation[],
+  deltaFrames: number,
+): TimelineState {
+  if (!locations.length || deltaFrames === 0) return state;
+  const deltaMs = Math.round(deltaFrames * 1000 / state.fps);
+  const byTrackLane = selectedCueIndexesByLane(locations);
+  let next = state;
+
+  for (const trackId of new Set(locations.map((location) => location.trackId))) {
+    const captions = captionsOnTrack(next, trackId);
+    if (!captions) continue;
+    const sourceEntries = (captions.sourceEntries ?? []).map((entry): CaptionSourceEntry => {
+      if (!isManualCaptionEntry(entry)) return entry;
+      const indexes = byTrackLane.get(`${trackId}\u0000${entry.id}`);
+      if (!indexes?.size) return entry;
+      return {
+        ...entry,
+        words: (entry.words ?? []).map((word, index) => indexes.has(index)
+          ? { ...word, start: word.start + deltaMs, end: word.end + deltaMs }
+          : word),
+      };
+    });
+    next = withCaptionTrack(next, trackId, { ...captions, sourceEntries });
+  }
+  return next;
+}
+
+function withCaptionTrack(state: TimelineState, trackId: TrackId, captions: CaptionsData): TimelineState {
+  const current = state.tracks?.[trackId] ?? { kind: 'caption' as const };
+  const next = { ...state, tracks: { ...state.tracks, [trackId]: { ...current, captions } } };
+  return trackId === defaultTrackId(state, 'caption') ? { ...next, captions } : next;
+}
+
+/** Move selected clips and caption cues as one immutable timeline state change. */
+export function moveTimelineSelectionByDelta(
+  state: TimelineState,
+  itemIds: readonly string[],
+  captionSelections: readonly CaptionSelectionRef[],
+  requestedDeltaFrames: number,
+  itemTrackShift: { from: TrackId; to: TrackId } | null = null,
+): TimelineState {
+  const deltaFrames = clampTimelineSelectionDelta(state, itemIds, captionSelections, requestedDeltaFrames);
+  const itemsMoved = moveItemsByDelta(state, [...itemIds], deltaFrames, itemTrackShift);
+  const manualMoved = moveManualCaptionSelections(
+    itemsMoved,
+    selectedManualCueLocations(state, captionSelections),
+    deltaFrames,
+  );
+  return moveAutomaticCaptionSelections(
+    manualMoved,
+    selectedAutomaticCueLocations(state, captionSelections),
+    itemIds,
+    deltaFrames,
+  );
+}

--- a/src/captions/captionGroupMove.ts
+++ b/src/captions/captionGroupMove.ts
@@ -1,4 +1,5 @@
 import { moveItemsByDelta } from '../editor/multiSelect';
+import { moveLockedItemIds } from '../editor/linkGroups';
 import {
   captionsOnTrack,
   defaultTrackId,
@@ -187,7 +188,12 @@ export function clampTimelineSelectionDelta(
   captionSelections: readonly CaptionSelectionRef[],
   requestedDeltaFrames: number,
 ): number {
-  const ids = new Set(itemIds);
+  const expandedItemIds = moveLockedItemIds(state, itemIds);
+  const ids = new Set(expandedItemIds);
+  if (expandedItemIds.some((id) => {
+    const item = state.items.find((candidate) => candidate.id === id);
+    return item ? state.tracks?.[item.track]?.locked : false;
+  })) return 0;
   const manualLocations = selectedManualCueLocations(state, captionSelections);
   const automaticLocations = selectedAutomaticCueLocations(state, captionSelections);
   let minDelta = Number.NEGATIVE_INFINITY;

--- a/src/captions/captionGroupMove.verify.ts
+++ b/src/captions/captionGroupMove.verify.ts
@@ -42,7 +42,11 @@ assert.equal(clampTimelineSelectionDelta(state, ['clip-a'], selections, -90), -3
 
 const moved = moveTimelineSelectionByDelta(state, ['clip-a'], selections, 15);
 assert.equal(moved.items[0]?.startFrame, 75);
-assert.deepEqual(moved.captions?.sourceEntries?.[0]?.words?.map(({ text, start, end }) => [text, start, end]), [
+assert.deepEqual(moved.captions?.sourceEntries?.[0]?.words?.map((word: { text: string; start: number; end: number }) => [
+  word.text,
+  word.start,
+  word.end,
+]), [
   ['First', 1_500, 2_500],
   ['Second', 3_500, 4_500],
   ['Outside', 7_000, 8_000],

--- a/src/captions/captionGroupMove.verify.ts
+++ b/src/captions/captionGroupMove.verify.ts
@@ -52,6 +52,27 @@ assert.deepEqual(moved.captions?.sourceEntries?.[0]?.words?.map((word: { text: s
   ['Outside', 7_000, 8_000],
 ], 'mixed clip/caption selections should move with one shared delta');
 
+const linkedState: TimelineState = {
+  ...state,
+  items: [
+    state.items[0]!,
+    { id: 'clip-linked', track: 'V1', startFrame: 10, durationInFrames: 30, kind: 'video', name: 'Linked', src: '/linked.mp4' },
+  ],
+  linkGroups: [{
+    id: 'link-a',
+    itemIds: ['clip-a', 'clip-linked'],
+    anchorItemId: 'clip-a',
+    mode: 'linked',
+  }],
+};
+const linkedClamped = moveTimelineSelectionByDelta(linkedState, ['clip-a'], selections, -30);
+assert.deepEqual(linkedClamped.items.map((item: { startFrame: number }) => item.startFrame), [50, 0]);
+assert.equal(
+  linkedClamped.captions?.sourceEntries?.[0]?.words?.[0]?.start,
+  667,
+  'linked clips and captions must use the same clamped delta at frame zero',
+);
+
 const automaticCaptions = {
   enabled: true,
   template: 'plain' as const,

--- a/src/captions/captionGroupMove.verify.ts
+++ b/src/captions/captionGroupMove.verify.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import type { TimelineState } from '../editor/types';
+import { appendManualCue, newManualCaptions } from './manualCaptions';
+import { buildCues } from './captionCues';
+
+const modulePath = './captionGroupMove';
+const {
+  clampTimelineSelectionDelta,
+  moveTimelineSelectionByDelta,
+  resolveCaptionDragSelection,
+} = await import(modulePath).catch(() => {
+  assert.fail('caption group movement must have a shared state transformation');
+});
+
+let captions = newManualCaptions();
+const laneId = captions.sourceEntries![0]!.id;
+captions = { ...captions, ...appendManualCue(captions, laneId, 'First', 1_000, 2_000) };
+captions = { ...captions, ...appendManualCue(captions, laneId, 'Second', 3_000, 4_000) };
+captions = { ...captions, ...appendManualCue(captions, laneId, 'Outside', 7_000, 8_000) };
+
+const selections = [
+  { trackId: 'C1', kind: 'manual' as const, laneId, cueIndex: 0 },
+  { trackId: 'C1', kind: 'manual' as const, laneId, cueIndex: 1 },
+];
+const state: TimelineState = {
+  fps: 30,
+  width: 1080,
+  height: 1920,
+  items: [{ id: 'clip-a', track: 'V1', startFrame: 60, durationInFrames: 90, kind: 'video', name: 'Video', src: '/a.mp4' }],
+  selectedId: 'clip-a',
+  selectedIds: ['clip-a'],
+  trackOrder: ['C1', 'V1'],
+  tracks: { C1: { kind: 'caption', captions }, V1: { kind: 'video' } },
+  captions,
+};
+
+assert.deepEqual(resolveCaptionDragSelection(selections[0], selections, ['clip-a']), {
+  captionSelections: selections,
+  itemIds: ['clip-a'],
+});
+assert.equal(clampTimelineSelectionDelta(state, ['clip-a'], selections, -90), -30);
+
+const moved = moveTimelineSelectionByDelta(state, ['clip-a'], selections, 15);
+assert.equal(moved.items[0]?.startFrame, 75);
+assert.deepEqual(moved.captions?.sourceEntries?.[0]?.words?.map(({ text, start, end }) => [text, start, end]), [
+  ['First', 1_500, 2_500],
+  ['Second', 3_500, 4_500],
+  ['Outside', 7_000, 8_000],
+], 'mixed clip/caption selections should move with one shared delta');
+
+const automaticCaptions = {
+  enabled: true,
+  template: 'plain' as const,
+  pacing: 'phrase' as const,
+  words: [
+    { text: 'Auto', start: 1_000, end: 1_400 },
+    { text: 'caption', start: 1_450, end: 2_000 },
+  ],
+};
+const automaticState: TimelineState = {
+  fps: 30,
+  width: 1080,
+  height: 1920,
+  items: [],
+  selectedId: null,
+  trackOrder: ['C1'],
+  tracks: { C1: { kind: 'caption', captions: automaticCaptions } },
+  captions: automaticCaptions,
+};
+const movedAutomatic = moveTimelineSelectionByDelta(
+  automaticState,
+  [],
+  [{ trackId: 'C1', kind: 'single', cueIndex: 0 }],
+  15,
+);
+assert.deepEqual(buildCues(movedAutomatic.captions!, [], 30).map(({ start, end }) => [start, end]), [
+  [1_500, 2_500],
+], 'automatic caption timing offsets must affect rendered cue timing');
+
+console.log('captionGroupMove.verify: unified caption selection movement OK');

--- a/src/captions/captionPreviewTarget.ts
+++ b/src/captions/captionPreviewTarget.ts
@@ -75,7 +75,14 @@ function manualTarget(captions: CaptionsData, items: TimelineItem[], fps: number
       const cueIndex = manualCueIndex(cue, lane.entry.words ?? []);
       if (cueIndex < 0) continue;
       const layout = group.anchor
-        ? { anchor: group.anchor, offsetXRatio: group.offsetXRatio, offsetYRatio: group.offsetYRatio }
+        ? {
+            anchor: group.anchor,
+            offsetXRatio: group.offsetXRatio,
+            offsetYRatio: group.offsetYRatio,
+            scale: group.scale,
+            rotation: group.rotation,
+            opacity: group.opacity,
+          }
         : captions.layout;
       return {
         kind: 'manual', laneId: lane.entry.id, cueIndex, cue, layout,
@@ -127,16 +134,61 @@ export function captionPreviewStylePatch(
   };
 }
 
+export function captionPreviewStyleResetPatch(
+  captions: CaptionsData,
+  target: CaptionPreviewTarget,
+): Partial<CaptionsData> {
+  if (target.kind === 'single') return { styleOverride: undefined };
+  return {
+    sourceEntries: captions.sourceEntries?.map((entry) => {
+      if (entry.id !== target.laneId) return entry;
+      const { style: _style, ...rest } = entry;
+      return rest;
+    }),
+  };
+}
+
 export function captionPreviewLayoutPatch(
   captions: CaptionsData,
   target: CaptionPreviewTarget,
   layout: CaptionLayout,
 ): Partial<CaptionsData> {
-  if (target.kind === 'single') return { layout };
+  const nextLayout = { ...target.layout, ...layout };
+  if (target.kind === 'single') return { layout: nextLayout };
   return {
     sourceEntries: captions.sourceEntries?.map((entry) => entry.id === target.laneId
-      ? { ...entry, anchor: layout.anchor, offsetXRatio: layout.offsetXRatio, offsetYRatio: layout.offsetYRatio }
+      ? {
+          ...entry,
+          anchor: nextLayout.anchor,
+          offsetXRatio: nextLayout.offsetXRatio,
+          offsetYRatio: nextLayout.offsetYRatio,
+          scale: nextLayout.scale,
+          rotation: nextLayout.rotation,
+          opacity: nextLayout.opacity,
+        }
       : entry),
+  };
+}
+
+export function captionPreviewLayoutResetPatch(
+  captions: CaptionsData,
+  target: CaptionPreviewTarget,
+): Partial<CaptionsData> {
+  if (target.kind === 'single') return { layout: undefined };
+  return {
+    sourceEntries: captions.sourceEntries?.map((entry) => {
+      if (entry.id !== target.laneId) return entry;
+      const {
+        anchor: _anchor,
+        offsetXRatio: _offsetXRatio,
+        offsetYRatio: _offsetYRatio,
+        scale: _scale,
+        rotation: _rotation,
+        opacity: _opacity,
+        ...rest
+      } = entry;
+      return rest;
+    }),
   };
 }
 

--- a/src/captions/captionPreviewTarget.ts
+++ b/src/captions/captionPreviewTarget.ts
@@ -134,20 +134,6 @@ export function captionPreviewStylePatch(
   };
 }
 
-export function captionPreviewStyleResetPatch(
-  captions: CaptionsData,
-  target: CaptionPreviewTarget,
-): Partial<CaptionsData> {
-  if (target.kind === 'single') return { styleOverride: undefined };
-  return {
-    sourceEntries: captions.sourceEntries?.map((entry) => {
-      if (entry.id !== target.laneId) return entry;
-      const { style: _style, ...rest } = entry;
-      return rest;
-    }),
-  };
-}
-
 export function captionPreviewLayoutPatch(
   captions: CaptionsData,
   target: CaptionPreviewTarget,
@@ -167,28 +153,6 @@ export function captionPreviewLayoutPatch(
           opacity: nextLayout.opacity,
         }
       : entry),
-  };
-}
-
-export function captionPreviewLayoutResetPatch(
-  captions: CaptionsData,
-  target: CaptionPreviewTarget,
-): Partial<CaptionsData> {
-  if (target.kind === 'single') return { layout: undefined };
-  return {
-    sourceEntries: captions.sourceEntries?.map((entry) => {
-      if (entry.id !== target.laneId) return entry;
-      const {
-        anchor: _anchor,
-        offsetXRatio: _offsetXRatio,
-        offsetYRatio: _offsetYRatio,
-        scale: _scale,
-        rotation: _rotation,
-        opacity: _opacity,
-        ...rest
-      } = entry;
-      return rest;
-    }),
   };
 }
 

--- a/src/captions/captionPreviewTarget.ts
+++ b/src/captions/captionPreviewTarget.ts
@@ -34,6 +34,16 @@ export interface ManualCaptionPreviewTarget extends BaseTarget {
 }
 
 export type CaptionPreviewTarget = SingleCaptionPreviewTarget | ManualCaptionPreviewTarget;
+export type CaptionPreviewNudgeDirection = 'left' | 'right' | 'up' | 'down';
+
+const NUDGE_DELTAS: Record<CaptionPreviewNudgeDirection, { x: number; y: number }> = {
+  left: { x: -1, y: 0 },
+  right: { x: 1, y: 0 },
+  up: { x: 0, y: -1 },
+  down: { x: 0, y: 1 },
+};
+
+const roundedRatio = (value: number): number => Math.round(value * 10_000) / 10_000;
 
 function activeCueIndex(rows: CueRow[], ms: number): number {
   for (let index = rows.length - 1; index >= 0; index -= 1) {
@@ -128,4 +138,21 @@ export function captionPreviewLayoutPatch(
       ? { ...entry, anchor: layout.anchor, offsetXRatio: layout.offsetXRatio, offsetYRatio: layout.offsetYRatio }
       : entry),
   };
+}
+
+export function captionPreviewNudgePatch(
+  captions: CaptionsData,
+  target: CaptionPreviewTarget,
+  direction: CaptionPreviewNudgeDirection,
+  stepRatio = 0.01,
+): Partial<CaptionsData> {
+  const anchor = target.layout?.anchor ?? 'bottom-center';
+  const delta = NUDGE_DELTAS[direction];
+  const verticalStorageSign = anchor.startsWith('bottom') || anchor === 'bottom' ? -1 : 1;
+  return captionPreviewLayoutPatch(captions, target, {
+    ...target.layout,
+    anchor,
+    offsetXRatio: roundedRatio((target.layout?.offsetXRatio ?? 0) + delta.x * stepRatio),
+    offsetYRatio: roundedRatio((target.layout?.offsetYRatio ?? 0) + delta.y * stepRatio * verticalStorageSign),
+  });
 }

--- a/src/captions/captionPreviewTarget.verify.ts
+++ b/src/captions/captionPreviewTarget.verify.ts
@@ -14,9 +14,7 @@ import {
 } from './renderStyles';
 import {
   captionPreviewLayoutPatch,
-  captionPreviewLayoutResetPatch,
   captionPreviewNudgePatch,
-  captionPreviewStyleResetPatch,
   captionPreviewStylePatch,
   captionPreviewTextPatch,
   findCaptionPreviewTarget,
@@ -138,12 +136,6 @@ assert.equal(textPatch?.sourceEntries?.[0]?.words?.[0]?.text, '预览已改字')
 
 const stylePatch = captionPreviewStylePatch(captions, target!, { color: '#ff0000' });
 assert.equal(stylePatch.sourceEntries?.[0]?.style?.color, '#ff0000');
-const styledCaptions = { ...captions, ...stylePatch };
-assert.equal(
-  captionPreviewStyleResetPatch(styledCaptions, findCaptionPreviewTarget(styledCaptions, [], 30, 1_500)!).sourceEntries?.[0]?.style,
-  undefined,
-  'style reset removes only the selected lane override',
-);
 
 const layoutPatch = captionPreviewLayoutPatch(captions, target!, {
   anchor: 'bottom-center', offsetXRatio: 0.1, offsetYRatio: 0.2,
@@ -158,10 +150,6 @@ const transformedCaptions = {
 };
 const transformedTarget = findCaptionPreviewTarget(transformedCaptions, [], 30, 1_500)!;
 assert.equal(transformedTarget.layout?.scale, 1.5, 'manual preview targets retain render transforms');
-const resetLayout = captionPreviewLayoutResetPatch(transformedCaptions, transformedTarget).sourceEntries?.[0];
-assert.equal(resetLayout?.anchor, undefined);
-assert.equal(resetLayout?.scale, undefined);
-assert.equal(resetLayout?.words?.[0]?.text, '画面里可编辑', 'layout reset preserves cue content');
 
 const positionedCaptions = { ...captions, ...layoutPatch };
 const positionedTarget = findCaptionPreviewTarget(positionedCaptions, [], 30, 1_500)!;

--- a/src/captions/captionPreviewTarget.verify.ts
+++ b/src/captions/captionPreviewTarget.verify.ts
@@ -1,11 +1,22 @@
 import assert from 'node:assert/strict';
 import { appendManualCue, newManualCaptions } from './manualCaptions';
+import { mapCaptionStyle } from './styleMap';
 import { captionTemplatePatch } from './captionTemplatePatch';
 import { captionPreviewOutsideClickAction } from './captionPreviewToolbar';
-import { captionPreviewTextColor, captionPreviewTextColorPatch, effectivePreset } from './renderStyles';
+import {
+  captionBoxStyle,
+  captionPreviewTextColor,
+  captionPreviewTextColorPatch,
+  containerStyle,
+  effectivePreset,
+  shadowBlurSize,
+  wordStyle,
+} from './renderStyles';
 import {
   captionPreviewLayoutPatch,
+  captionPreviewLayoutResetPatch,
   captionPreviewNudgePatch,
+  captionPreviewStyleResetPatch,
   captionPreviewStylePatch,
   captionPreviewTextPatch,
   findCaptionPreviewTarget,
@@ -46,6 +57,54 @@ assert.equal(
   '#ffffff',
   'whole-line captions expose their normal text color',
 );
+assert.equal(shadowBlurSize('0 2px 5px #000, 0 3px 12px #0008'), 12, 'shadow controls read the dominant blur layer');
+assert.equal(
+  wordStyle({ ...karaokePreset, strokeColor: '#ff0000', strokeWidth: 2, strokeOpacity: 0.5 }, true).WebkitTextStroke,
+  '2px rgba(255, 0, 0, 0.5)',
+  'caption renderer applies stroke opacity without fading the fill',
+);
+assert.deepEqual(
+  captionBoxStyle({ ...karaokePreset, highlightBackground: '#000000', boxBorderColor: '#ffffff', boxBorderWidth: 2, boxBorderRadius: 10 }, true),
+  {
+    background: '#000000', border: '2px solid #ffffff', borderRadius: 10, boxShadow: undefined,
+    boxSizing: 'border-box', padding: '0 .14em',
+  },
+  'caption box fields are converted into paintable CSS',
+);
+assert.match(
+  String(containerStyle(karaokePreset, 'tiktok', 1080, 1920, {
+    anchor: 'middle-center', scale: 1.25, rotation: -12, opacity: 0.6,
+  }).transform),
+  /rotate\(-12deg\) scale\(1\.25\)/,
+  'whole-caption transforms are consumed by the shared preview/export layout',
+);
+assert.deepEqual(
+  mapCaptionStyle({
+    strokeOpacity: 0.4,
+    textShadowSize: 14,
+    boxBorderColor: '#abcdef',
+    boxBorderWidth: 3,
+    boxBorderOpacity: 0.8,
+    boxBorderRadius: 12,
+    boxShadow: '0 4px 18px #0008',
+    boxShadowSize: 18,
+  }, 1920),
+  {
+    styleOverride: {
+      strokeOpacity: 0.4,
+      textShadowSize: 14,
+      boxBorderColor: '#abcdef',
+      boxBorderWidth: 3,
+      boxBorderOpacity: 0.8,
+      boxBorderRadius: 12,
+      boxShadow: '0 4px 18px #0008',
+      boxShadowSize: 18,
+    },
+    pacing: undefined,
+    ignored: [],
+  },
+  'agent caption style input can reach every newly rendered paint field',
+);
 
 assert.deepEqual(
   captionPreviewOutsideClickAction({
@@ -79,12 +138,30 @@ assert.equal(textPatch?.sourceEntries?.[0]?.words?.[0]?.text, '预览已改字')
 
 const stylePatch = captionPreviewStylePatch(captions, target!, { color: '#ff0000' });
 assert.equal(stylePatch.sourceEntries?.[0]?.style?.color, '#ff0000');
+const styledCaptions = { ...captions, ...stylePatch };
+assert.equal(
+  captionPreviewStyleResetPatch(styledCaptions, findCaptionPreviewTarget(styledCaptions, [], 30, 1_500)!).sourceEntries?.[0]?.style,
+  undefined,
+  'style reset removes only the selected lane override',
+);
 
 const layoutPatch = captionPreviewLayoutPatch(captions, target!, {
   anchor: 'bottom-center', offsetXRatio: 0.1, offsetYRatio: 0.2,
 });
 assert.equal(layoutPatch.sourceEntries?.[0]?.offsetXRatio, 0.1);
 assert.equal(layoutPatch.sourceEntries?.[0]?.offsetYRatio, 0.2);
+const transformedCaptions = {
+  ...captions,
+  ...captionPreviewLayoutPatch(captions, target!, {
+    anchor: 'bottom-center', offsetXRatio: 0.1, offsetYRatio: 0.2, scale: 1.5, rotation: 15, opacity: 0.75,
+  }),
+};
+const transformedTarget = findCaptionPreviewTarget(transformedCaptions, [], 30, 1_500)!;
+assert.equal(transformedTarget.layout?.scale, 1.5, 'manual preview targets retain render transforms');
+const resetLayout = captionPreviewLayoutResetPatch(transformedCaptions, transformedTarget).sourceEntries?.[0];
+assert.equal(resetLayout?.anchor, undefined);
+assert.equal(resetLayout?.scale, undefined);
+assert.equal(resetLayout?.words?.[0]?.text, '画面里可编辑', 'layout reset preserves cue content');
 
 const positionedCaptions = { ...captions, ...layoutPatch };
 const positionedTarget = findCaptionPreviewTarget(positionedCaptions, [], 30, 1_500)!;

--- a/src/captions/captionPreviewTarget.verify.ts
+++ b/src/captions/captionPreviewTarget.verify.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { appendManualCue, newManualCaptions } from './manualCaptions';
 import { captionTemplatePatch } from './captionTemplatePatch';
+import { captionPreviewOutsideClickAction } from './captionPreviewToolbar';
 import { captionPreviewTextColor, captionPreviewTextColorPatch, effectivePreset } from './renderStyles';
 import {
   captionPreviewLayoutPatch,
@@ -44,6 +45,29 @@ assert.equal(
   captionPreviewTextColor({ ...karaokePreset, wholeLine: true }),
   '#ffffff',
   'whole-line captions expose their normal text color',
+);
+
+assert.deepEqual(
+  captionPreviewOutsideClickAction({
+    editing: true,
+    popoverOpen: false,
+    insideEditor: false,
+    insideToolbar: false,
+    draftChanged: true,
+  }),
+  { closeEditor: true, commitDraft: true, closePopover: false },
+  'clicking canvas space commits a changed direct-edit draft before closing the editor',
+);
+assert.deepEqual(
+  captionPreviewOutsideClickAction({
+    editing: true,
+    popoverOpen: true,
+    insideEditor: false,
+    insideToolbar: true,
+    draftChanged: true,
+  }),
+  { closeEditor: false, commitDraft: false, closePopover: false },
+  'toolbar pointerdown must not cancel the toolbar click or close the active editor',
 );
 
 const target = findCaptionPreviewTarget(captions, [], 30, 1_500);

--- a/src/captions/captionPreviewTarget.verify.ts
+++ b/src/captions/captionPreviewTarget.verify.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
 import { appendManualCue, newManualCaptions } from './manualCaptions';
+import { captionTemplatePatch } from './captionTemplatePatch';
+import { captionPreviewTextColor, captionPreviewTextColorPatch, effectivePreset } from './renderStyles';
 import {
   captionPreviewLayoutPatch,
   captionPreviewStylePatch,
@@ -10,6 +12,38 @@ import {
 let captions = newManualCaptions();
 const laneId = captions.sourceEntries![0]!.id;
 captions = { ...captions, ...appendManualCue(captions, laneId, '画面里可编辑', 1_000, 2_000) };
+
+const overriddenCaptions = {
+  ...captions,
+  styleOverride: { color: '#123456' },
+  sourceEntries: captions.sourceEntries?.map((entry) => ({
+    ...entry,
+    style: { color: '#654321' },
+  })),
+};
+const templatePatch = captionTemplatePatch(overriddenCaptions, 'tiktok');
+assert.equal(templatePatch.template, 'tiktok', 'choosing a template writes the selected template');
+assert.equal(templatePatch.styleOverride, undefined, 'choosing a template clears track-level style overrides');
+assert.equal(templatePatch.sourceEntries?.[0]?.style, undefined, 'choosing a template clears lane-level style overrides');
+assert.equal(templatePatch.sourceEntries?.[0]?.words?.[0]?.text, '画面里可编辑', 'template changes preserve caption content');
+
+const karaokePreset = {
+  ...effectivePreset(overriddenCaptions),
+  color: '#ffffff',
+  highlightColor: '#0a0a0a',
+  wholeLine: false,
+};
+assert.equal(captionPreviewTextColor(karaokePreset), '#0a0a0a', 'preview controls expose the visible karaoke color');
+assert.deepEqual(
+  captionPreviewTextColorPatch(karaokePreset, '#ff0000'),
+  { color: '#ff0000', highlightColor: '#ff0000' },
+  'changing preview text color updates active and inactive karaoke words',
+);
+assert.equal(
+  captionPreviewTextColor({ ...karaokePreset, wholeLine: true }),
+  '#ffffff',
+  'whole-line captions expose their normal text color',
+);
 
 const target = findCaptionPreviewTarget(captions, [], 30, 1_500);
 assert.equal(target?.kind, 'manual', 'manual multi-lane captions expose a preview edit target');

--- a/src/captions/captionPreviewTarget.verify.ts
+++ b/src/captions/captionPreviewTarget.verify.ts
@@ -4,6 +4,7 @@ import { captionTemplatePatch } from './captionTemplatePatch';
 import { captionPreviewTextColor, captionPreviewTextColorPatch, effectivePreset } from './renderStyles';
 import {
   captionPreviewLayoutPatch,
+  captionPreviewNudgePatch,
   captionPreviewStylePatch,
   captionPreviewTextPatch,
   findCaptionPreviewTarget,
@@ -60,6 +61,30 @@ const layoutPatch = captionPreviewLayoutPatch(captions, target!, {
 });
 assert.equal(layoutPatch.sourceEntries?.[0]?.offsetXRatio, 0.1);
 assert.equal(layoutPatch.sourceEntries?.[0]?.offsetYRatio, 0.2);
+
+const positionedCaptions = { ...captions, ...layoutPatch };
+const positionedTarget = findCaptionPreviewTarget(positionedCaptions, [], 30, 1_500)!;
+assert.equal(
+  captionPreviewNudgePatch(positionedCaptions, positionedTarget, 'left').sourceEntries?.[0]?.offsetXRatio,
+  0.09,
+  'left arrow moves the caption one percent of the composition width',
+);
+assert.equal(
+  captionPreviewNudgePatch(positionedCaptions, positionedTarget, 'up').sourceEntries?.[0]?.offsetYRatio,
+  0.21,
+  'bottom anchors store upward movement as a positive vertical offset',
+);
+
+const topLayoutPatch = captionPreviewLayoutPatch(captions, target!, {
+  anchor: 'top-center', offsetXRatio: 0, offsetYRatio: 0.2,
+});
+const topCaptions = { ...captions, ...topLayoutPatch };
+const topTarget = findCaptionPreviewTarget(topCaptions, [], 30, 1_500)!;
+assert.equal(
+  captionPreviewNudgePatch(topCaptions, topTarget, 'up').sourceEntries?.[0]?.offsetYRatio,
+  0.19,
+  'top anchors store upward movement as a negative vertical delta',
+);
 
 const deletePatch = captionPreviewTextPatch(captions, target!, '');
 assert.equal(deletePatch?.sourceEntries?.[0]?.words?.length, 0);

--- a/src/captions/captionPreviewToolbar.ts
+++ b/src/captions/captionPreviewToolbar.ts
@@ -1,0 +1,31 @@
+export interface CaptionPreviewOutsideClickInput {
+  editing: boolean;
+  popoverOpen: boolean;
+  insideEditor: boolean;
+  insideToolbar: boolean;
+  draftChanged: boolean;
+}
+
+export interface CaptionPreviewOutsideClickAction {
+  closeEditor: boolean;
+  commitDraft: boolean;
+  closePopover: boolean;
+}
+
+export function captionPreviewOutsideClickAction({
+  editing,
+  popoverOpen,
+  insideEditor,
+  insideToolbar,
+  draftChanged,
+}: CaptionPreviewOutsideClickInput): CaptionPreviewOutsideClickAction {
+  // Native capture runs before a toolbar button's React click. Keeping the
+  // editor mounted for toolbar pointerdown prevents the pending click from
+  // being cancelled by a re-render.
+  const closeEditor = editing && !insideEditor && !insideToolbar;
+  return {
+    closeEditor,
+    commitDraft: closeEditor && draftChanged,
+    closePopover: popoverOpen && !insideToolbar,
+  };
+}

--- a/src/captions/captionSelection.ts
+++ b/src/captions/captionSelection.ts
@@ -1,0 +1,136 @@
+import { buildCues } from './captionCues';
+import { findCaptionPreviewTarget, type CaptionPreviewTarget } from './captionPreviewTarget';
+import { captionPages } from './exportCaptions';
+import { effectivePreset } from './renderStyles';
+import {
+  captionsOnTrack,
+  timelineTrackIds,
+  trackKind,
+  type TimelineItem,
+  type TimelineState,
+  type TrackId,
+} from '../editor/types';
+import type { CaptionsData } from './types';
+
+export type CaptionSelectionRef =
+  | { trackId: TrackId; kind: 'single'; cueIndex: number }
+  | { trackId: TrackId; kind: 'manual'; laneId: string; cueIndex: number };
+
+export interface CaptionSelectOptions {
+  additive?: boolean;
+  preserveWithItems?: boolean;
+  toggle?: boolean;
+}
+
+export interface SelectedCaptionInspector {
+  trackId: TrackId;
+  captions: CaptionsData;
+  target: CaptionPreviewTarget;
+}
+
+export function captionSelectionRef(trackId: TrackId, target: CaptionPreviewTarget): CaptionSelectionRef {
+  return target.kind === 'single'
+    ? { trackId, kind: 'single', cueIndex: target.cueIndex }
+    : { trackId, kind: 'manual', laneId: target.laneId, cueIndex: target.cueIndex };
+}
+
+export function captionSelectionKey(selection: CaptionSelectionRef | null): string | null {
+  if (!selection) return null;
+  return selection.kind === 'single'
+    ? `${selection.trackId}:single:${selection.cueIndex}`
+    : `${selection.trackId}:manual:${selection.laneId}:${selection.cueIndex}`;
+}
+
+/** Resolve every visible caption cue whose frames intersect a marquee range. */
+export function captionSelectionsInFrameRange(
+  trackId: TrackId,
+  captions: CaptionsData,
+  items: TimelineItem[],
+  fps: number,
+  rangeStartFrame: number,
+  rangeEndFrame: number,
+): CaptionSelectionRef[] {
+  if (!captions.enabled) return [];
+  const lo = Math.min(rangeStartFrame, rangeEndFrame);
+  const hi = Math.max(rangeStartFrame, rangeEndFrame);
+  const seen = new Set<string>();
+  const selections: CaptionSelectionRef[] = [];
+
+  for (const page of captionPages(captions, items, fps)) {
+    const startFrame = Math.max(0, Math.round(page.start * fps / 1000));
+    const endFrame = Math.max(startFrame + 1, Math.round(page.end * fps / 1000));
+    if (endFrame <= lo || startFrame >= hi) continue;
+    const target = findCaptionPreviewTarget(captions, items, fps, (page.start + page.end) / 2);
+    if (!target) continue;
+    const selection = captionSelectionRef(trackId, target);
+    const key = captionSelectionKey(selection);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    selections.push(selection);
+  }
+  return selections;
+}
+
+/** Select every visible cue on unlocked caption tracks. */
+export function allCaptionSelections(state: TimelineState): CaptionSelectionRef[] {
+  return timelineTrackIds(state).flatMap((trackId) => {
+    if (trackKind(state, trackId) !== 'caption' || state.tracks?.[trackId]?.locked) return [];
+    const captions = captionsOnTrack(state, trackId);
+    return captions
+      ? captionSelectionsInFrameRange(trackId, captions, state.items, state.fps, 0, Number.MAX_SAFE_INTEGER)
+      : [];
+  });
+}
+
+export function resolveCaptionSelection(
+  state: TimelineState,
+  selection: CaptionSelectionRef | null,
+): SelectedCaptionInspector | null {
+  if (!selection) return null;
+  const captions = captionsOnTrack(state, selection.trackId);
+  if (!captions?.enabled) return null;
+  const preset = effectivePreset(captions);
+
+  if (selection.kind === 'single') {
+    const rows = buildCues(captions, state.items, state.fps);
+    const cue = rows[selection.cueIndex];
+    return cue ? {
+      trackId: selection.trackId,
+      captions,
+      target: {
+        kind: 'single',
+        key: `single:${selection.cueIndex}:${cue.start}:${cue.end}`,
+        cueIndex: selection.cueIndex,
+        cue,
+        rows,
+        preset,
+        layout: captions.layout,
+      },
+    } : null;
+  }
+
+  const entry = captions.sourceEntries?.find((candidate) => candidate.id === selection.laneId);
+  const cue = entry?.words?.[selection.cueIndex];
+  if (!entry || !cue) return null;
+  return {
+    trackId: selection.trackId,
+    captions,
+    target: {
+      kind: 'manual',
+      key: `manual:${entry.id}:${selection.cueIndex}:${cue.start}:${cue.end}`,
+      laneId: entry.id,
+      cueIndex: selection.cueIndex,
+      cue,
+      preset: entry.style ? { ...preset, ...entry.style } : preset,
+      layout: {
+        ...captions.layout,
+        anchor: entry.anchor ?? captions.layout?.anchor,
+        offsetXRatio: entry.offsetXRatio ?? captions.layout?.offsetXRatio,
+        offsetYRatio: entry.offsetYRatio ?? captions.layout?.offsetYRatio,
+        scale: entry.scale ?? captions.layout?.scale,
+        rotation: entry.rotation ?? captions.layout?.rotation,
+        opacity: entry.opacity ?? captions.layout?.opacity,
+      },
+    },
+  };
+}

--- a/src/captions/captionSelection.verify.ts
+++ b/src/captions/captionSelection.verify.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { appendManualCue, newManualCaptions } from './manualCaptions';
+import type { TimelineState } from '../editor/types';
+
+const modulePath = './captionSelection';
+const {
+  allCaptionSelections,
+  captionSelectionKey,
+  captionSelectionsInFrameRange,
+  resolveCaptionSelection,
+} = await import(modulePath).catch(() => {
+  assert.fail('caption selection must have a caption-owned identity and resolution layer');
+});
+
+let captions = newManualCaptions();
+const laneId = captions.sourceEntries![0]!.id;
+captions = { ...captions, ...appendManualCue(captions, laneId, 'First', 1_000, 2_000) };
+captions = { ...captions, ...appendManualCue(captions, laneId, 'Second', 3_000, 4_000) };
+
+const state: TimelineState = {
+  fps: 30,
+  width: 1080,
+  height: 1920,
+  items: [],
+  selectedId: null,
+  trackOrder: ['C1', 'C2'],
+  tracks: {
+    C1: { kind: 'caption', captions },
+    C2: { kind: 'caption', captions, locked: true },
+  },
+  captions,
+};
+
+const hits = captionSelectionsInFrameRange('C1', captions, [], 30, 29, 61);
+assert.deepEqual(hits, [{ trackId: 'C1', kind: 'manual', laneId, cueIndex: 0 }]);
+assert.equal(captionSelectionKey(hits[0]), `C1:manual:${laneId}:0`);
+assert.equal(resolveCaptionSelection(state, hits[0])?.target.kind, 'manual');
+assert.deepEqual(allCaptionSelections(state), [
+  { trackId: 'C1', kind: 'manual', laneId, cueIndex: 0 },
+  { trackId: 'C1', kind: 'manual', laneId, cueIndex: 1 },
+], 'select-all should ignore locked caption tracks');
+
+console.log('captionSelection.verify: caption selection identity and range rules OK');

--- a/src/captions/captionSelectionInteraction.ts
+++ b/src/captions/captionSelectionInteraction.ts
@@ -1,0 +1,33 @@
+import { captionSelectionKey, type CaptionSelectionRef } from './captionSelection';
+
+export const CAPTION_SELECTION_TIMELINE_CLIP_SELECTOR = '[data-timeline-clip]';
+export const CAPTION_SELECTION_TIMELINE_REGION_SELECTOR = '[data-caption-selection-region="timeline"]';
+export const CAPTION_SELECTION_TIMELINE_HEAD_SELECTOR = '.cc-timeline-ruler, .cc-track-head';
+export const CAPTION_SELECTION_OWNER_SELECTOR = '[data-caption-selection-owner]';
+
+export function shouldClearCaptionSelectionFromPointer(context: {
+  insideTimelineClip: boolean;
+  insideTimelineBlank: boolean;
+  insideTimelineHead: boolean;
+  additive: boolean;
+}): boolean {
+  return context.insideTimelineBlank && !context.insideTimelineHead && !context.additive;
+}
+
+export function updateCaptionSelections(
+  current: CaptionSelectionRef[],
+  selection: CaptionSelectionRef,
+  mode: 'add' | 'toggle',
+): CaptionSelectionRef[] {
+  const key = captionSelectionKey(selection);
+  const exists = current.some((item) => captionSelectionKey(item) === key);
+  if (mode === 'toggle' && exists) {
+    return current.filter((item) => captionSelectionKey(item) !== key);
+  }
+  return exists ? current : [...current, selection];
+}
+
+/** macOS converts Ctrl+click into a contextmenu event after pointerdown. */
+export function captionContextMenuIntent(ctrlKey: boolean): 'ignore-after-toggle' | 'open-menu' {
+  return ctrlKey ? 'ignore-after-toggle' : 'open-menu';
+}

--- a/src/captions/captionSelectionInteraction.verify.ts
+++ b/src/captions/captionSelectionInteraction.verify.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+
+const modulePath = './captionSelectionInteraction';
+const { captionContextMenuIntent, shouldClearCaptionSelectionFromPointer, updateCaptionSelections } = await import(modulePath).catch(() => {
+  assert.fail('caption selection interaction rules must be independent of React event handlers');
+});
+
+const first = { trackId: 'C1', kind: 'single' as const, cueIndex: 0 };
+const second = { trackId: 'C1', kind: 'single' as const, cueIndex: 1 };
+assert.deepEqual(updateCaptionSelections([], first, 'add'), [first]);
+assert.deepEqual(updateCaptionSelections([first], second, 'add'), [first, second]);
+assert.deepEqual(updateCaptionSelections([first, second], first, 'toggle'), [second]);
+assert.equal(captionContextMenuIntent(true), 'ignore-after-toggle');
+assert.equal(captionContextMenuIntent(false), 'open-menu');
+
+assert.equal(shouldClearCaptionSelectionFromPointer({
+  insideTimelineClip: false,
+  insideTimelineBlank: true,
+  insideTimelineHead: false,
+  additive: false,
+}), true);
+assert.equal(shouldClearCaptionSelectionFromPointer({
+  insideTimelineClip: false,
+  insideTimelineBlank: true,
+  insideTimelineHead: true,
+  additive: false,
+}), false);
+assert.equal(shouldClearCaptionSelectionFromPointer({
+  insideTimelineClip: false,
+  insideTimelineBlank: true,
+  insideTimelineHead: false,
+  additive: true,
+}), false);
+
+console.log('captionSelectionInteraction.verify: caption pointer selection rules OK');

--- a/src/captions/captionTemplatePatch.ts
+++ b/src/captions/captionTemplatePatch.ts
@@ -1,0 +1,23 @@
+import type { CaptionStyleOverride } from './styles';
+import type { CaptionsData, CaptionTemplate } from './types';
+
+/**
+ * Applying a template replaces the current appearance while preserving cue
+ * content, timing, placement, and lane metadata.
+ */
+export function captionTemplatePatch(
+  captions: CaptionsData,
+  template: CaptionTemplate,
+  styleOverride?: CaptionStyleOverride,
+): Partial<CaptionsData> {
+  const sourceEntries = captions.sourceEntries?.map((entry) => {
+    if (!entry.style) return entry;
+    const { style: _style, ...rest } = entry;
+    return rest;
+  });
+  return {
+    template,
+    styleOverride,
+    ...(sourceEntries ? { sourceEntries } : {}),
+  };
+}

--- a/src/captions/captionTimelineClipboard.ts
+++ b/src/captions/captionTimelineClipboard.ts
@@ -1,0 +1,84 @@
+import type { TimelineItem } from '../editor/types';
+import {
+  appendManualCue,
+  appendManualLane,
+  isManualCaptionEntry,
+  newManualCaptions,
+} from './manualCaptions';
+import type { CaptionsData } from './types';
+
+export interface CaptionTimelineCue {
+  text: string;
+  start: number;
+  end: number;
+}
+
+export interface CaptionTimelineClipboard {
+  kind: 'caption';
+  cues: CaptionTimelineCue[];
+}
+
+function cleanCue(cue: CaptionTimelineCue): CaptionTimelineCue | null {
+  const text = cue.text.trim();
+  if (!text || !Number.isFinite(cue.start) || !Number.isFinite(cue.end)) return null;
+  const start = Math.max(0, Math.round(cue.start));
+  return { text, start, end: Math.max(start + 1, Math.round(cue.end)) };
+}
+
+/** Snapshot selected cues as structured, timeline-relative content. */
+export function createCaptionTimelineClipboard(cues: readonly CaptionTimelineCue[]): CaptionTimelineClipboard | null {
+  const snapshot = cues
+    .map(cleanCue)
+    .filter((cue): cue is CaptionTimelineCue => cue !== null)
+    .sort((a, b) => a.start - b.start || a.end - b.end);
+  return snapshot.length ? { kind: 'caption', cues: snapshot } : null;
+}
+
+/** Place the first copied cue at the playhead while preserving subsequent gaps. */
+export function createCaptionTrackFromClipboard(
+  clipboard: CaptionTimelineClipboard | null,
+  startAtMs: number,
+): CaptionsData | null {
+  if (!clipboard?.cues.length || !Number.isFinite(startAtMs)) return null;
+  const base = clipboard.cues[0]!.start;
+  let captions = newManualCaptions();
+  const laneId = captions.sourceEntries?.[0]?.id;
+  if (!laneId) return null;
+  for (const cue of clipboard.cues) {
+    const start = Math.max(0, Math.round(startAtMs + cue.start - base));
+    const patch = appendManualCue(captions, laneId, cue.text, start, start + (cue.end - cue.start));
+    if (!patch) return null;
+    captions = { ...captions, ...patch };
+  }
+  return captions;
+}
+
+export function createTranslatedCaptionTrack(text: string, start: number, end: number): CaptionsData | null {
+  return createCaptionTrackFromClipboard(createCaptionTimelineClipboard([{ text, start, end }]), start);
+}
+
+/** Paste structured cues into the current caption track when parent track creation is unavailable. */
+export function appendCaptionClipboardToTrack(
+  captions: CaptionsData,
+  items: TimelineItem[],
+  clipboard: CaptionTimelineClipboard | null,
+  startAtMs: number,
+): Partial<CaptionsData> | null {
+  if (!clipboard?.cues.length || !Number.isFinite(startAtMs)) return null;
+  let next = captions;
+  let lane = next.sourceEntries?.find(isManualCaptionEntry);
+  if (!lane) {
+    next = { ...next, ...appendManualLane(next, items) };
+    lane = next.sourceEntries?.find(isManualCaptionEntry);
+  }
+  if (!lane) return null;
+
+  const base = clipboard.cues[0]!.start;
+  for (const cue of clipboard.cues) {
+    const start = Math.max(0, Math.round(startAtMs + cue.start - base));
+    const patch = appendManualCue(next, lane.id, cue.text, start, start + cue.end - cue.start);
+    if (!patch) return null;
+    next = { ...next, ...patch };
+  }
+  return next;
+}

--- a/src/captions/captionTimelineClipboard.verify.ts
+++ b/src/captions/captionTimelineClipboard.verify.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+
+const modulePath = './captionTimelineClipboard';
+const {
+  createCaptionTimelineClipboard,
+  createCaptionTrackFromClipboard,
+  createTranslatedCaptionTrack,
+  appendCaptionClipboardToTrack,
+} = await import(modulePath).catch(() => {
+  assert.fail('caption timeline clipboard must have a caption-owned data layer');
+});
+
+const clipboard = createCaptionTimelineClipboard([
+  { text: ' First ', start: 1_000, end: 2_400 },
+  { text: 'Second', start: 3_100, end: 4_000 },
+]);
+assert.deepEqual(clipboard?.cues, [
+  { text: 'First', start: 1_000, end: 2_400 },
+  { text: 'Second', start: 3_100, end: 4_000 },
+]);
+
+const pasted = createCaptionTrackFromClipboard(clipboard, 6_000);
+assert.deepEqual(pasted?.sourceEntries?.[0]?.words, [
+  { text: 'First', start: 6_000, end: 7_400 },
+  { text: 'Second', start: 8_100, end: 9_000 },
+], 'paste should anchor the first cue at the playhead and preserve relative gaps');
+
+assert.deepEqual(createTranslatedCaptionTrack('Translated', 1_000, 2_400)?.sourceEntries?.[0]?.words, [
+  { text: 'Translated', start: 1_000, end: 2_400 },
+]);
+assert.equal(createCaptionTimelineClipboard([]), null);
+assert.equal(createTranslatedCaptionTrack('   ', 1_000, 2_400), null);
+
+const existing = createTranslatedCaptionTrack('Existing', 500, 900)!;
+const appended = appendCaptionClipboardToTrack(existing, [], clipboard, 10_000);
+assert.deepEqual(appended?.sourceEntries?.[0]?.words, [
+  { text: 'Existing', start: 500, end: 900 },
+  { text: 'First', start: 10_000, end: 11_400 },
+  { text: 'Second', start: 12_100, end: 13_000 },
+], 'a caption lane without parent timeline wiring should still paste structured cues into its current track');
+
+console.log('captionTimelineClipboard.verify: structured caption copy/paste rules OK');

--- a/src/captions/lanes.ts
+++ b/src/captions/lanes.ts
@@ -23,6 +23,9 @@ export interface LaneGroup {
   anchor?: CaptionAnchor;
   offsetXRatio?: number;
   offsetYRatio?: number;
+  scale?: number;
+  rotation?: number;
+  opacity?: number;
   /** lanes to render at this position, top-to-bottom */
   lanes: LanePage[];
 }
@@ -31,12 +34,19 @@ const policyOf = (c: CaptionsData): CaptionLayoutPolicy =>
   c.layoutPolicy ?? { mode: 'auto-stack' };
 
 /** Entry's placement point: slotId of manual-slots → slot geometry; otherwise entry's own anchor; none → shared block. */
-function placementOf(entry: CaptionSourceEntry, policy: CaptionLayoutPolicy): { anchor?: CaptionAnchor; offsetXRatio?: number; offsetYRatio?: number } {
+function placementOf(entry: CaptionSourceEntry, policy: CaptionLayoutPolicy): Omit<LaneGroup, 'lanes'> {
   if (policy.mode === 'manual-slots' && entry.slotId) {
     const slot = policy.slots.find((s) => s.id === entry.slotId);
     if (slot) return { anchor: slot.anchor, offsetXRatio: slot.offsetXRatio, offsetYRatio: slot.offsetYRatio };
   }
-  if (entry.anchor) return { anchor: entry.anchor, offsetXRatio: entry.offsetXRatio, offsetYRatio: entry.offsetYRatio };
+  if (entry.anchor) return {
+    anchor: entry.anchor,
+    offsetXRatio: entry.offsetXRatio,
+    offsetYRatio: entry.offsetYRatio,
+    scale: entry.scale,
+    rotation: entry.rotation,
+    opacity: entry.opacity,
+  };
   return {};
 }
 
@@ -81,7 +91,9 @@ export function buildLaneGroups(captions: CaptionsData, items: TimelineItem[], f
   const groups = new Map<string, LaneGroup>();
   for (const { entry, lane } of capped) {
     const place = placementOf(entry, policy);
-    const key = place.anchor ? `${place.anchor}|${place.offsetXRatio ?? 0}|${place.offsetYRatio ?? 0}` : '__block__';
+    const key = place.anchor
+      ? `${place.anchor}|${place.offsetXRatio ?? 0}|${place.offsetYRatio ?? 0}|${place.scale ?? 1}|${place.rotation ?? 0}|${place.opacity ?? 1}`
+      : '__block__';
     let g = groups.get(key);
     if (!g) { g = { ...place, lanes: [] }; groups.set(key, g); }
     g.lanes.push(lane);

--- a/src/captions/renderStyles.ts
+++ b/src/captions/renderStyles.ts
@@ -1,11 +1,24 @@
 import type { CSSProperties } from 'react';
 import type { CaptionLayout, CaptionsData, CaptionTemplate } from './types';
-import { CAPTION_STYLE_BY_ID, type CaptionStyle } from './styles';
+import { CAPTION_STYLE_BY_ID, type CaptionStyle, type CaptionStyleOverride } from './styles';
 
 /** Template preset merged with the caption's explicit style override. */
 export function effectivePreset(captions: CaptionsData): CaptionStyle {
   const preset = CAPTION_STYLE_BY_ID[captions.template];
   return captions.styleOverride ? { ...preset, ...captions.styleOverride } : preset;
+}
+
+/** Color currently painted by the direct-edit preview. */
+export function captionPreviewTextColor(preset: CaptionStyle): string {
+  return preset.wholeLine ? preset.color : preset.highlightColor;
+}
+
+/** Keep active and inactive karaoke words consistent after a color edit. */
+export function captionPreviewTextColorPatch(
+  preset: CaptionStyle,
+  color: string,
+): CaptionStyleOverride {
+  return preset.wholeLine ? { color } : { color, highlightColor: color };
 }
 
 /** Per-word look; active marks the word currently being spoken. */

--- a/src/captions/renderStyles.ts
+++ b/src/captions/renderStyles.ts
@@ -21,15 +21,109 @@ export function captionPreviewTextColorPatch(
   return preset.wholeLine ? { color } : { color, highlightColor: color };
 }
 
+const clampedOpacity = (value: number | undefined): number => Math.max(0, Math.min(1, value ?? 1));
+
+function colorWithOpacity(color: string, opacity: number | undefined): string {
+  const amount = clampedOpacity(opacity);
+  if (amount === 1) return color;
+  const hex = /^#([\da-f]{3,8})$/i.exec(color.trim())?.[1];
+  if (hex) {
+    const expanded = hex.length === 3 || hex.length === 4
+      ? [...hex].map((part) => `${part}${part}`).join('')
+      : hex;
+    if (expanded.length === 6 || expanded.length === 8) {
+      const red = Number.parseInt(expanded.slice(0, 2), 16);
+      const green = Number.parseInt(expanded.slice(2, 4), 16);
+      const blue = Number.parseInt(expanded.slice(4, 6), 16);
+      const sourceAlpha = expanded.length === 8 ? Number.parseInt(expanded.slice(6, 8), 16) / 255 : 1;
+      return `rgba(${red}, ${green}, ${blue}, ${Number((sourceAlpha * amount).toFixed(3))})`;
+    }
+  }
+  const rgb = /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i.exec(color.trim());
+  if (rgb) {
+    const sourceAlpha = rgb[4] === undefined ? 1 : Number(rgb[4]);
+    return `rgba(${Number(rgb[1])}, ${Number(rgb[2])}, ${Number(rgb[3])}, ${Number((sourceAlpha * amount).toFixed(3))})`;
+  }
+  return `color-mix(in srgb, ${color} ${Math.round(amount * 1000) / 10}%, transparent)`;
+}
+
+const SHADOW_BLUR_RE = /^(\s*(?:inset\s+)?-?(?:\d+(?:\.\d+)?|\.\d+)(?:px)?\s+-?(?:\d+(?:\.\d+)?|\.\d+)(?:px)?\s+)(-?(?:\d+(?:\.\d+)?|\.\d+)(?:px)?)/i;
+
+function splitShadowLayers(shadow: string): string[] {
+  const layers: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < shadow.length; index += 1) {
+    const character = shadow[index];
+    if (character === '(') depth += 1;
+    if (character === ')') depth = Math.max(0, depth - 1);
+    if (character === ',' && depth === 0) {
+      layers.push(shadow.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  layers.push(shadow.slice(start).trim());
+  return layers.filter(Boolean);
+}
+
+export function shadowBlurSize(shadow: string | undefined): number {
+  if (!shadow || shadow.trim().toLowerCase() === 'none') return 0;
+  return splitShadowLayers(shadow).reduce((largest, layer) => {
+    const match = SHADOW_BLUR_RE.exec(layer);
+    return match ? Math.max(largest, Math.max(0, Number.parseFloat(match[2]!))) : largest;
+  }, 0);
+}
+
+function shadowWithBlurSize(shadow: string | undefined, size: number | undefined, fallback: string): string {
+  if (size === undefined) return shadow ?? 'none';
+  const blur = Math.max(0, size);
+  if (blur === 0) return 'none';
+  const layers = splitShadowLayers(!shadow || shadow.trim().toLowerCase() === 'none' ? fallback : shadow);
+  let targetIndex = -1;
+  let largest = -1;
+  layers.forEach((layer, index) => {
+    const match = SHADOW_BLUR_RE.exec(layer);
+    if (!match) return;
+    const current = Math.max(0, Number.parseFloat(match[2]!));
+    if (current >= largest) {
+      largest = current;
+      targetIndex = index;
+    }
+  });
+  if (targetIndex < 0) return shadowWithBlurSize(fallback, blur, fallback);
+  layers[targetIndex] = layers[targetIndex]!.replace(SHADOW_BLUR_RE, `$1${blur}px`);
+  return layers.join(', ');
+}
+
 /** Per-word look; active marks the word currently being spoken. */
 export function wordStyle(preset: CaptionStyle, active: boolean): CSSProperties {
   return {
     color: active ? preset.highlightColor : preset.color,
-    background: active && preset.highlightBackground ? preset.highlightBackground : 'transparent',
-    borderRadius: preset.highlightBackground ? 6 : 0,
-    padding: preset.highlightBackground ? '0 .14em' : 0,
-    textShadow: preset.textShadow,
-    WebkitTextStroke: preset.strokeWidth ? `${preset.strokeWidth}px ${preset.strokeColor}` : undefined,
+    textShadow: shadowWithBlurSize(preset.textShadow, preset.textShadowSize, '0 3px 8px #000000aa'),
+    paintOrder: 'stroke fill',
+    WebkitTextStroke: preset.strokeWidth
+      ? `${preset.strokeWidth}px ${colorWithOpacity(preset.strokeColor, preset.strokeOpacity)}`
+      : undefined,
+  };
+}
+
+export function captionBoxStyle(preset: CaptionStyle, active: boolean, wholeLine = false): CSSProperties {
+  const visible = wholeLine || active;
+  const background = wholeLine ? preset.background : (active ? preset.highlightBackground : undefined);
+  const borderWidth = preset.boxBorderWidth ?? 0;
+  const boxShadow = shadowWithBlurSize(preset.boxShadow, preset.boxShadowSize, '0 4px 12px #00000088');
+  const hasConfiguredBox = wholeLine
+    ? Boolean(preset.background || borderWidth || boxShadow !== 'none')
+    : Boolean(preset.highlightBackground || borderWidth || boxShadow !== 'none');
+  return {
+    background: background ?? 'transparent',
+    border: visible && borderWidth > 0
+      ? `${borderWidth}px solid ${colorWithOpacity(preset.boxBorderColor ?? preset.strokeColor, preset.boxBorderOpacity)}`
+      : undefined,
+    borderRadius: hasConfiguredBox ? (preset.boxBorderRadius ?? 6) : 0,
+    boxShadow: visible && boxShadow !== 'none' ? boxShadow : undefined,
+    boxSizing: 'border-box',
+    padding: wholeLine ? (hasConfiguredBox ? '0.1em 0.42em' : 0) : (hasConfiguredBox ? '0 .14em' : 0),
   };
 }
 
@@ -38,6 +132,9 @@ function hasLayout(layout: CaptionLayout | undefined): layout is CaptionLayout {
     layout.anchor !== undefined
     || layout.offsetXRatio !== undefined
     || layout.offsetYRatio !== undefined
+    || layout.scale !== undefined
+    || layout.rotation !== undefined
+    || layout.opacity !== undefined
   );
 }
 
@@ -77,16 +174,19 @@ export function containerStyle(
   const horizontal = anchor.endsWith('left') ? 'left' : anchor.endsWith('right') ? 'right' : 'center';
   const offsetX = (layout.offsetXRatio ?? 0) * width;
   const offsetY = (layout.offsetYRatio ?? 0) * height;
+  const visualTransform = `rotate(${layout.rotation ?? 0}deg) scale(${layout.scale ?? 1})`;
   const placed: CSSProperties = {
     ...base,
     alignItems: horizontal === 'left' ? 'flex-start' : horizontal === 'right' ? 'flex-end' : 'center',
     textAlign: horizontal,
+    opacity: clampedOpacity(layout.opacity),
+    transformOrigin: 'center',
   };
   if (vertical === 'middle') {
-    return { ...placed, top: '50%', transform: `translateY(-50%) translate(${offsetX}px, ${offsetY}px)` };
+    return { ...placed, top: '50%', transform: `translateY(-50%) translate(${offsetX}px, ${offsetY}px) ${visualTransform}` };
   }
   if (vertical === 'top') {
-    return { ...placed, top: height * 0.08, transform: `translate(${offsetX}px, ${offsetY}px)` };
+    return { ...placed, top: height * 0.08, transform: `translate(${offsetX}px, ${offsetY}px) ${visualTransform}` };
   }
-  return { ...placed, bottom: height * 0.08, transform: `translate(${offsetX}px, ${-offsetY}px)` };
+  return { ...placed, bottom: height * 0.08, transform: `translate(${offsetX}px, ${-offsetY}px) ${visualTransform}` };
 }

--- a/src/captions/renderStyles.verify.ts
+++ b/src/captions/renderStyles.verify.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import { captionBoxStyle, captionPreviewTextColor, wordStyle } from './renderStyles';
+import type { CaptionStyle } from './styles';
+
+const preset: CaptionStyle = {
+  id: 'plain',
+  label: 'Test',
+  labelZh: '测试',
+  hint: '测试',
+  fontFamily: 'Inter',
+  fontSize: 0.04,
+  fontWeight: 700,
+  color: '#ffffff',
+  highlightColor: '#ffffff',
+  highlightBackground: '#ff2e63',
+  strokeColor: '#112233',
+  strokeWidth: 4,
+  strokeOpacity: 0.5,
+  textShadow: '0 3px 8px #000000aa',
+  boxBorderColor: '#abcdef',
+  boxBorderWidth: 3,
+  boxBorderOpacity: 0.25,
+  boxBorderRadius: 12,
+  boxShadow: '0 4px 12px #00000088',
+};
+
+const text = wordStyle(preset, false);
+assert.equal(text.paintOrder, 'stroke fill');
+assert.equal(text.WebkitTextStroke, '4px rgba(17, 34, 51, 0.5)');
+assert.equal(text.textShadow, '0 3px 8px #000000aa');
+assert.equal(captionPreviewTextColor({ ...preset, color: '#ffffff', highlightColor: '#0a0a0a' }), '#0a0a0a');
+assert.equal(captionPreviewTextColor({ ...preset, wholeLine: true, color: '#f8f8f8', highlightColor: '#0a0a0a' }), '#f8f8f8');
+
+assert.equal(wordStyle({ ...preset, textShadowSize: 0 }, false).textShadow, 'none');
+const activeBox = captionBoxStyle(preset, true);
+assert.equal(activeBox.background, '#ff2e63');
+assert.equal(activeBox.border, '3px solid rgba(171, 205, 239, 0.25)');
+assert.equal(activeBox.borderRadius, 12);
+assert.equal(activeBox.boxShadow, '0 4px 12px #00000088');
+assert.equal(captionBoxStyle({ ...preset, boxShadowSize: 0 }, true).boxShadow, undefined);
+
+console.log('renderStyles.verify: caption render style controls remain aligned');

--- a/src/captions/resolve.ts
+++ b/src/captions/resolve.ts
@@ -152,7 +152,15 @@ export function applyWordOverrides(
     const ov = overrides[indices[j]];
     if (ov?.hidden) continue;
     if (ov?.forceBreak && out.length > 0) breakBefore.add(out.length);
-    out.push(ov?.text ? { ...words[j], text: ov.text } : words[j]);
+    const timingOffsetMs = ov?.timingOffsetMs ?? 0;
+    out.push(ov?.text || timingOffsetMs
+      ? {
+          ...words[j],
+          ...(ov?.text ? { text: ov.text } : {}),
+          start: words[j]!.start + timingOffsetMs,
+          end: words[j]!.end + timingOffsetMs,
+        }
+      : words[j]);
   }
   return { words: out, breakBefore };
 }

--- a/src/captions/styleMap.ts
+++ b/src/captions/styleMap.ts
@@ -20,7 +20,7 @@ const str = (v: unknown): string | undefined => (typeof v === 'string' && v.trim
 
 /** Style fields with no representable target → reported, not applied. */
 const UNSUPPORTED = new Set([
-  'opacity', 'align', 'variant', 'strokeOpacity', 'maxLines', 'maxCharactersPerLine', 'maxCharsPerLine',
+  'opacity', 'align', 'variant', 'maxLines', 'maxCharactersPerLine', 'maxCharsPerLine',
   'lineHeight', 'letterSpacing', 'direction', 'highlightUnit', 'hidePunctuation',
   'backgroundColor', 'backgroundOpacity', 'backgroundRadius', 'backgroundOff',
 ]);
@@ -55,6 +55,8 @@ export function mapCaptionStyle(json: Record<string, unknown>, canvasHeight: num
   if (strokeColor) o.strokeColor = strokeColor;
   if (json.strokeOff === true) o.strokeWidth = 0;
   else { const sw = num(json.strokeWidth); if (sw !== undefined) o.strokeWidth = sw; }
+  const strokeOpacity = num(json.strokeOpacity);
+  if (strokeOpacity !== undefined) o.strokeOpacity = Math.max(0, Math.min(1, strokeOpacity));
 
   // current-word highlight
   const highlightColor = str(json.highlightColor);
@@ -73,6 +75,21 @@ export function mapCaptionStyle(json: Record<string, unknown>, canvasHeight: num
     const a = Math.max(0, Math.min(100, shadowStrength)) / 100;
     o.textShadow = a === 0 ? 'none' : `0 2px 8px rgba(0,0,0,${a.toFixed(2)})`;
   }
+  const textShadowSize = num(json.textShadowSize);
+  if (textShadowSize !== undefined) o.textShadowSize = Math.max(0, textShadowSize);
+
+  const boxBorderColor = str(json.boxBorderColor);
+  if (boxBorderColor) o.boxBorderColor = boxBorderColor;
+  const boxBorderWidth = num(json.boxBorderWidth);
+  if (boxBorderWidth !== undefined) o.boxBorderWidth = Math.max(0, boxBorderWidth);
+  const boxBorderOpacity = num(json.boxBorderOpacity);
+  if (boxBorderOpacity !== undefined) o.boxBorderOpacity = Math.max(0, Math.min(1, boxBorderOpacity));
+  const boxBorderRadius = num(json.boxBorderRadius);
+  if (boxBorderRadius !== undefined) o.boxBorderRadius = Math.max(0, boxBorderRadius);
+  const boxShadow = str(json.boxShadow);
+  if (boxShadow) o.boxShadow = boxShadow;
+  const boxShadowSize = num(json.boxShadowSize);
+  if (boxShadowSize !== undefined) o.boxShadowSize = Math.max(0, boxShadowSize);
 
   // typography / display
   const tt = str(json.textTransform);
@@ -86,7 +103,14 @@ export function mapCaptionStyle(json: Record<string, unknown>, canvasHeight: num
   const pacing = mapPacing(json.pacing);
 
   // Report any input fields this build cannot represent.
-  const applied = new Set(['font', 'sizePx', 'fontSizeRatio', 'weight', 'fontWeight', 'color', 'strokeColor', 'strokeWidth', 'strokeOff', 'highlightColor', 'highlightBackground', 'highlightOff', 'shadow', 'shadowStrength', 'shadowOff', 'textTransform', 'displayMode', 'wordsPerPage', 'pacing']);
+  const applied = new Set([
+    'font', 'sizePx', 'fontSizeRatio', 'weight', 'fontWeight', 'color',
+    'strokeColor', 'strokeWidth', 'strokeOff', 'strokeOpacity',
+    'highlightColor', 'highlightBackground', 'highlightOff',
+    'shadow', 'shadowStrength', 'shadowOff', 'textShadowSize',
+    'boxBorderColor', 'boxBorderWidth', 'boxBorderOpacity', 'boxBorderRadius', 'boxShadow', 'boxShadowSize',
+    'textTransform', 'displayMode', 'wordsPerPage', 'pacing',
+  ]);
   for (const k of Object.keys(json)) if (!applied.has(k)) ignored.push(k + (UNSUPPORTED.has(k) ? '' : '?'));
 
   return { styleOverride: o, pacing, ignored };

--- a/src/captions/styles.ts
+++ b/src/captions/styles.ts
@@ -16,7 +16,19 @@ export interface CaptionStyle {
   highlightBackground?: string;
   strokeColor: string;
   strokeWidth: number;
+  /** Opacity of the text stroke, independent from the fill. Defaults to 1. */
+  strokeOpacity?: number;
   textShadow: string;
+  /** Dominant text-shadow blur radius. Zero disables the shadow. */
+  textShadowSize?: number;
+  /** Optional border, radius and shadow for the active/whole-line caption box. */
+  boxBorderColor?: string;
+  boxBorderWidth?: number;
+  boxBorderOpacity?: number;
+  boxBorderRadius?: number;
+  boxShadow?: string;
+  /** Dominant box-shadow blur radius. Zero disables the shadow. */
+  boxShadowSize?: number;
   textTransform?: 'none' | 'uppercase';
   displayMode?: 'stacked';
   wordsPerPage?: number;

--- a/src/captions/types.ts
+++ b/src/captions/types.ts
@@ -15,6 +15,9 @@ export interface CaptionLayout {
   anchor?: CaptionAnchor;
   offsetXRatio?: number;
   offsetYRatio?: number;
+  scale?: number;
+  rotation?: number;
+  opacity?: number;
 }
 
 // Captions = a styled singleton overlay burned onto the video, separate
@@ -121,6 +124,9 @@ export interface CaptionSourceEntry {
   anchor?: CaptionAnchor;
   offsetXRatio?: number;
   offsetYRatio?: number;
+  scale?: number;
+  rotation?: number;
+  opacity?: number;
   widthRatio?: number;
   heightRatio?: number;
   /** per-source style overrides layered over template+styleOverride (source_update.style) */

--- a/src/captions/types.ts
+++ b/src/captions/types.ts
@@ -94,6 +94,8 @@ export interface CaptionWordOverride {
   hidden?: boolean;
   text?: string;
   forceBreak?: boolean;
+  /** Display-only timing shift for moving generated cues independently of source media. */
+  timingOffsetMs?: number;
 }
 
 // ──Multi-lane captions (edit_captions three brothers positions / layout_policy / source_update)──

--- a/src/i18n/dict/en/captions.ts
+++ b/src/i18n/dict/en/captions.ts
@@ -91,6 +91,13 @@ export default {
   '结束秒数': 'End time in seconds',
   '字幕文字': 'Caption text',
   '删除': 'Delete',
+  '复制': 'Copy',
+  '粘贴': 'Paste',
+  '添加到 AI 对话框': 'Add to AI composer',
+  '无法复制字幕，请检查剪贴板权限': 'Could not copy the caption. Check clipboard permission.',
+  '无法读取剪贴板，请检查剪贴板权限': 'Could not read the clipboard. Check clipboard permission.',
+  '剪贴板里没有可粘贴的文字': 'The clipboard has no text to paste.',
+  '字幕翻译没有返回文字': 'Caption translation returned no text.',
   // CaptionsControls — Language variants/bilingual translations
   '字幕语言（文本变体）': 'Caption language (text variant)',
   '原文（source）': 'Original (source)',


### PR DESCRIPTION
## Summary

- make caption template, color, direct-edit draft, outside-click selection, and keyboard nudge behavior deterministic
- render advanced caption styling, transforms, text stroke, shadow, background, and border controls consistently
- add caption-owned structured selection identities, Cmd/Ctrl toggle rules, cue context-menu actions, and structured caption copy/paste
- add unified movement logic for manual captions, generated captions, ordinary clips, and linked clips, including frame-zero clamping and generated-cue timing offsets
- add focused verification for selection, group movement, cue menus, clipboard behavior, render styles, and English caption strings

## Cross-PR integration dependency

This PR intentionally contains the caption-owned data model and backward-compatible `CaptionTrackLane` surface only. Full editor-wide behavior depends on the generic timeline work in #23:

- `Editor.tsx` must own the global caption selection lifecycle and cross-surface Inspector/preview synchronization
- `Timeline.tsx`, `TrackLane.tsx`, and `useTimelinePointer.ts` must connect marquee selection and mixed clip/caption drag previews to one undoable commit
- the shared shortcut layer must connect global Cmd/Ctrl+A, C, and V behavior
- parent timeline commands must create cross-track/new caption tracks for paste and translated cues

Until #23 provides that parent wiring, the caption-side movement helpers are verified foundations, not a claim that mixed clip/caption group dragging is end-to-end complete. This PR does not modify #23 generic timeline files, #25 media files, or #26 chat files.

## Verification

- focused caption verification: 9 checks passed
- `npm test` passed
- `npm run build` passed (1160 modules transformed)
- `git diff --check` passed
- Impeccable detector: 0 findings
- Open Code Review/Codex review: no remaining High or Critical findings; linked-selection clamp issue found during review and fixed

## Visual verification boundary

No official OpenChatCut UI screenshot was captured in this batch. The available local `8880` listener belonged to a different project, so it was not used as false visual evidence. The caption context menu, multi-selection appearance, and complete #23-connected interaction path still require acceptance in the real OpenChatCut editor.

This PR remains a Draft until that integration and visual acceptance are complete.