### PR TITLE
fix(agent): add missing BytePlus ModelArk catalog entries

### DIFF
--- a/assets/model-capabilities/models-dev.json
+++ b/assets/model-capabilities/models-dev.json
@@ -7769,6 +7769,30 @@
           "medium",
           "high"
         ]
+      },
+      "deepseek-v3-2-251201": {
+        "contextWindowTokens": 131072,
+        "maxInputTokens": 98304,
+        "maxOutputTokens": 32768,
+        "input": [
+          "text"
+        ],
+        "supportsTools": true,
+        "reasoning": true,
+        "reasoningEfforts": []
+      },
+      "seed-2-0-pro-260328": {
+        "contextWindowTokens": 262144,
+        "maxInputTokens": 262144,
+        "maxOutputTokens": 131072,
+        "input": [
+          "text",
+          "image",
+          "video"
+        ],
+        "supportsTools": true,
+        "reasoning": true,
+        "reasoningEfforts": []
       }
     }
   }

--- a/scripts/update-llm-model-capabilities.mjs
+++ b/scripts/update-llm-model-capabilities.mjs
@@ -58,6 +58,28 @@ const BYTEPLUS_MODELS = {
     reasoning: true,
     reasoningEfforts: ['minimal', 'low', 'medium', 'high'],
   },
+  // Verified directly against GET /api/v3/models (token_limits) on the
+  // account's ModelArk endpoint; both were missing from the catalog and
+  // fell back to the unknown-model defaults (8192/2048), which made the
+  // agent trim requests to a fraction of what these models actually support.
+  'deepseek-v3-2-251201': {
+    contextWindowTokens: 131072,
+    maxInputTokens: 98304,
+    maxOutputTokens: 32768,
+    input: ['text'],
+    supportsTools: true,
+    reasoning: true,
+    reasoningEfforts: [],
+  },
+  'seed-2-0-pro-260328': {
+    contextWindowTokens: 262144,
+    maxInputTokens: 262144,
+    maxOutputTokens: 131072,
+    input: ['text', 'image', 'video'],
+    supportsTools: true,
+    reasoning: true,
+    reasoningEfforts: [],
+  },
 };
 const OUTPUT_PATH = resolve(
   dirname(fileURLToPath(import.meta.url)),


### PR DESCRIPTION
## Summary
- `deepseek-v3-2-251201` and `seed-2-0-pro-260328` (BytePlus ModelArk) were missing from the hand-vendored `BYTEPLUS_MODELS` catalog in `scripts/update-llm-model-capabilities.mjs` / `assets/model-capabilities/models-dev.json` (BytePlus has no `models.dev` provider, so these entries are hand-maintained).
- Missing entries meant `resolveModelCapabilities()` fell back to the unknown-model defaults (8,192 context / 2,048 output). That fallback context window is smaller than OpenChatCut's own system prompt + tool schemas, so `context-compaction.ts` correctly refused to send the request at all (`"The current request is too large for this model context window..."`) on every single turn, regardless of conversation length.
- Verified the real limits directly against the account's live ModelArk endpoint (`GET /api/v3/models`, which returns per-model `token_limits`): `deepseek-v3-2-251201` → 131,072 context / 32,768 max output; `seed-2-0-pro-260328` → 262,144 context / 131,072 max output. Added both to the catalog JSON and to the generator script so they survive the next `models.dev` resync.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint scripts/update-llm-model-capabilities.mjs` — clean
- [x] `node -e "JSON.parse(...)"` — catalog JSON still valid
- [x] Ran `resolveModelCapabilities({ backend: 'api', provider: 'byteplus', modelId })` for both new model IDs — resolves to the real vendor values with `source: 'catalog'`, `estimated: false`; a genuinely unknown model id still correctly falls back to the conservative defaults
- [x] `tsx src/agent/ai-sdk.verify.ts`, `tsx src/agent/context-compaction.verify.ts`, `tsx src/agent/model-selection.verify.ts`, `tsx src/agent/local-models.verify.ts`, `tsx src/agent/vision.verify.ts`, `tsx server/keystore.verify.ts` — all pass

