### PR TITLE
fix(i18n): localize sequence panel

### DIFF
--- a/src/i18n/dict/en/library.ts
+++ b/src/i18n/dict/en/library.ts
@@ -2,8 +2,10 @@
 export default {
   // LibraryPanel main/sub tab
   '我的素材': 'My Media',
+  '序列': 'Sequences',
   '资源库': 'Library',
   '文字稿': 'Transcript',
+  '点击把序列作为引用实例加入当前时间线；修改子序列会同步到所有实例。': 'Click a sequence to add it to the current timeline as a linked instance. Changes to a child sequence sync to every instance.',
   'MG 动画': 'Motion Graphics',
   '音效': 'Sound Effects',
   '音频效果': 'Audio FX',

--- a/src/i18n/dict/en/timeline.ts
+++ b/src/i18n/dict/en/timeline.ts
@@ -204,6 +204,7 @@ export default {
   '出点 (O)': 'Out point (O)',
   // ── TimelineTabs.tsx ──
   '单击切换 · 双击重命名': 'Click to switch · double-click to rename',
+  '序列 {n}': 'Sequence {n}',
   '删除该序列': 'Delete this sequence',
   '＋序列': '＋ Sequence',
   '复制当前序列': 'Duplicate current sequence',

--- a/src/library/LibraryPanel.tsx
+++ b/src/library/LibraryPanel.tsx
@@ -123,6 +123,10 @@ interface LibraryPanelProps {
 
 const MAIN_TABS = ['我的素材', '序列', '资源库', '文字稿', '字幕', '技能'] as const;
 const SUB_TABS = ['MG 动画', '音效', '转场', '特效', '缩放', 'LUT'] as const;
+function localizeDefaultSequenceName(name: string, t: ReturnType<typeof useT>): string {
+  const match = /^序列 (\d+)$/.exec(name);
+  return match ? t('序列 {n}', { n: match[1]! }) : name;
+}
 export function LibraryPanel({ semanticScopeId, templates, onAddTemplate, onAddAudio, playerRef, fps, items, sequenceOptions, onAddSequence, trackOptions, captionTracks, onSetCaptions, onCreateCaptionTrack, onUpdateCaptions, onSetItemTranscript, onToggleWord, onCleanScript, onSetGapCap, onSetTranscriptPlayOrder, onReorderTrackItems, onClearEdits, assets, mediaFolders, usedAssetIds, offlineAssetIds, onAssetLoadError, onImportMedia, onImportMobileMedia, onAddMediaItem, onAddMediaAssetsToTimeline, onUseMediaAI, onCreateMediaFolder, onRenameMediaFolder, onDeleteMediaFolder, onMoveMediaAssets, onRenameMediaAsset, onRenameMediaAssets, onSetMediaAssetFavorite, onSetMediaAssetsFavorite, onRemoveMediaAsset, onRemoveMediaAssets, onPasteMediaAssets, onRelinkMediaAsset, creativeMode, onCreativeModeChange, onAddSolid, onUseTemplateAI, selectedItem, onApplyTransition, onApplyFx, onApplyZoom }: LibraryPanelProps) {
   const t = useT();
   const selKind = selectedItem?.kind ?? null;
@@ -206,7 +210,7 @@ export function LibraryPanel({ semanticScopeId, templates, onAddTemplate, onAddA
                 onClick={() => onAddSequence(option.id)}
                 className="cc-sequence-row"
               >
-                <span className="cc-sequence-name">{option.name}</span>
+                <span className="cc-sequence-name">{localizeDefaultSequenceName(option.name, t)}</span>
                 <span className="cc-sequence-duration">{(option.durationInFrames / fps).toFixed(1)}s</span>
               </button>
             ))}


### PR DESCRIPTION
## Summary

- Add English translations for the Sequence tab and its helper text.
- Localize default names such as `序列 1` to `Sequence 1`.
- Preserve user-defined sequence names unchanged.

## Validation

- Oxlint passed.
- Vite production build passed.
- `git diff --check` passed.

Closes #53