### PR TITLE
test(agent): make external skill verification newline agnostic

### DIFF
--- a/server/external-agent/external-skill.verify.mjs
+++ b/server/external-agent/external-skill.verify.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
 const skillRoot = resolve(root, 'skills/openchatcut');
 const skillPath = resolve(skillRoot, 'SKILL.md');
-const skill = readFileSync(skillPath, 'utf8');
+const skill = readFileSync(skillPath, 'utf8').replace(/\r\n?/g, '\n');
 
 assert.match(skill, /^---\nname: openchatcut\ndescription: .+\n---/);
 assert.ok(skill.split('\n').length <= 500, 'SKILL.md must stay within 500 lines');


### PR DESCRIPTION
## 变更

将外部技能验证中读取的 \`SKILL.md\` 内容统一规范为 LF 换行，再执行结构校验。

## 原因

Windows 工作区可能检出 CRLF 换行，导致本身有效的技能文档验证失败。这个改动只影响测试输入规范化，不改变运行时代码或技能内容。

## 验证

- \`npx tsx server/external-agent/external-skill.verify.mjs\`
- \`npx oxlint server/external-agent/external-skill.verify.mjs\`
- \`git diff --check\`

这是一个独立的小型测试稳定性修复，作为 Draft PR 提交，方便维护者审阅。