### PR TITLE
fix(export): accept bundled product media during preflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,97 +45,359 @@
     "verify:desktop-worker-lifecycle": "tsx --tsconfig tsconfig.node.json desktop/native-asr-worker-lifecycle.verify.ts",
     "verify:desktop-update": "tsx desktop/update-service.verify.ts && tsx desktop/update-packaging.verify.ts && tsx src/ui/upstreamUpdate.verify.ts && tsx src/ui/upstreamUpdateDesktop.verify.ts && tsx --tsconfig tsconfig.app.json src/ui/upstream-update-notice.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/settings/settings-version.verify.tsx",
     "verify:toolbar-tooltips": "tsx src/media/media-toolbar-tooltips.verify.tsx && tsx src/components/generation-activity.verify.tsx && tsx src/components/topbar-tooltips.verify.tsx",
-    "verify:export-adaptive": "npx tsx src/export/exportDestination.verify.ts && npx tsx src/export/exportRoutePlanner.verify.ts && npx tsx src/export/materializeBlobMedia.verify.ts && npx tsx src/export/serverExportOperation.verify.ts && npx tsx server/plugins/export-destination.verify.ts && npx tsx server/plugins/export-stage.verify.ts && npx tsx server/plugins/export-media-plan.verify.ts && npx tsx server/plugins/export-submission.verify.ts",
+    "verify:export-adaptive": "npx tsx src/export/exportDestination.verify.ts && npx tsx src/export/exportRoutePlanner.verify.ts && npx tsx src/export/materializeBlobMedia.verify.ts && npx tsx src/export/serverExportOperation.verify.ts && npx tsx server/plugins/export-destination.verify.ts && npx tsx server/plugins/export-stage.verify.ts && npx tsx server/plugins/export-media-plan.verify.ts && npx tsx server/plugins/export-product-assets.verify.ts && npx tsx server/plugins/export-submission.verify.ts",
     "test": "node scripts/run-tests.mjs",
     "test:serial": "node remotion/performance.verify.mjs && tsx src/transcript/local-asr-warmup.verify.ts && tsx src/transcript/assemblyai.verify.ts && tsx src/transcript/assemblyai-resume.verify.ts && tsx src/transcript/transcribe-jobs.verify.ts && tsx src/persist/mediaIntelligenceStores.verify.ts && tsx src/editor/rateStretch.verify.ts && tsx server/media-acceleration.verify.ts && tsx server/plugins/scene-detection.verify.ts && tsx server/plugins/stock.verify.ts && tsx src/agent/proposal.verify.ts && tsx src/agent/external-edit-session.verify.ts && tsx src/components/chat/widget-parse.verify.ts && tsx src/agent/tools/generation-tool-input.verify.ts && tsx server/plugins/image.verify.ts && tsx server/plugins/video.verify.ts && tsx server/plugins/music.verify.ts && tsx server/plugins/music-media.verify.ts && tsx server/plugins/sound.verify.ts && tsx server/plugins/voice.verify.ts && tsx src/agent/tools/followup-tools.verify.ts && tsx src/agent/tools/clean-script-rules.verify.ts && tsx src/agent/tools/mg-export-params.verify.ts && tsx src/agent/tools/scene-detection-tools.verify.ts && tsx src/agent/tools/isolate-voice-tools.verify.ts && tsx src/agent/tools/template-tools.verify.ts && tsx src/agent/tools/script-tools.verify.ts && tsx src/agent/tools/timeline-target-tools.verify.ts && tsx src/agent/tools/track-tools.verify.ts && tsx server/plugins/generation-jobs.verify.ts && tsx server/plugins/export-runtime.verify.ts && tsx server/plugins/export-params.verify.ts && tsx src/export/browserExport.verify.ts && tsx src/agent/ai-sdk.verify.ts && tsx server/llm-proxy.verify.ts && tsx server/external-agent/broker.verify.ts && tsx server/plugins/project-store.verify.ts && tsx server/plugins/extension-store.verify.ts && tsx server/plugins/normalize-media.verify.ts && tsx src/persist/projectStore.verify.ts && tsx src/persist/design-style-metadata.verify.ts && tsx src/persist/designStyleTransfer.verify.ts && tsx src/captions/manualCaptions.verify.ts && tsx src/captions/captionPreviewTarget.verify.ts && tsx src/agent/tools/captions-track-order.verify.ts && tsx src/skins.verify.ts && tsx src/theme-tokenization.verify.ts && tsx server/mobile-upload-service.verify.ts && tsx src/media/mobileUploadApi.verify.ts && tsx src/tracking/tracking.verify.ts && tsx src/media/semantic-search/semanticSearch.verify.ts && tsx src/color/autoGrade.verify.ts && tsx server/plugins/auto-grade.verify.ts && tsx src/transcript/phrases.verify.ts && tsx src/agent/tools/transcript-read.verify.ts && tsx src/export/quality.verify.ts && tsx src/export/autoQa.verify.ts && tsx server/plugins/export-qa.verify.ts && tsx src/agent/tools/export-qa-tools.verify.ts && tsx src/persist/migrations/migrations.verify.ts && tsx server/keystore.verify.ts && tsx server/key-probes.verify.ts && tsx src/agent/settings/agent-settings.verify.ts && tsx src/editor/layouts.verify.ts && tsx src/audio/silence.verify.ts && tsx src/editor/silenceRebuild.verify.ts && tsx src/color/scopes.verify.ts && tsx src/audio/beats.verify.ts && tsx src/editor/keyframes.verify.ts && tsx src/editor/camSwitch.verify.ts && tsx src/export/fcpxml.verify.ts && tsx src/agent/timelineDelta.verify.ts && tsx server/plugins/extract-frames.verify.ts && tsx src/agent/tools/undo-tools.verify.ts && tsx src/editor/clipFit.verify.ts && tsx src/editor/sourceLimit.verify.ts && tsx src/editor/rippleChain.verify.ts && tsx src/editor/snap.verify.ts && tsx src/transcript/cutPad.verify.ts && tsx src/agent/tools/track-gaps.verify.ts && tsx src/persist/uploadRefs.verify.ts && tsx server/plugins/result-download.verify.ts && tsx src/agent/systemPromptOrder.verify.ts && tsx src/review/reviewModel.verify.ts && tsx src/editor/historyGesture.verify.ts && tsx src/agent/abortedTurn.verify.ts && tsx src/agent/changeLog.verify.ts && tsx server/plugins/reference-mime.verify.ts && tsx src/components/inspector/inspector-controls.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineFitRange.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timeline-clip-duration.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/trackOverlap.verify.ts && node src/components/timeline/playhead-watchdog.verify.mjs && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineSeek.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/trackDelete.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/track-mute-visual.verify.ts && npm run test:contrib-timeline-preview",
     "posttest": "npm run verify:background-fill && npm run verify:speech-providers && npm run verify:desktop-worker-lifecycle && npm run verify:server-runs",
     "verify:server-runs": "tsx server/agent-runs/tool-catalog-generation.verify.ts && tsx server/agent-runs/executor.verify.ts && tsx server/agent-runs/tool-policy.verify.ts && tsx server/agent-runs/store.verify.ts && tsx server/agent-runs/store-approval.verify.ts && tsx server/agent-runs/store-capability.verify.ts && tsx server/agent-runs/routes.verify.ts && tsx src/agent/useServerRun.verify.ts && tsx src/agent/serverRunFetchEventStream.verify.ts && tsx src/agent/serverRunSessionStorage.verify.ts && tsx src/agent/serverRunModelHistory.verify.ts && tsx src/agent/serverRunOwnership.verify.ts && tsx src/agent/serverRunToolExecutor.verify.ts && tsx src/agent/serverRunToolRecovery.verify.ts && tsx src/agent/useAgentHistoryActions.verify.ts && tsx src/components/chat/serverRunInspector.verify.ts",
     "verify:background-fill": "tsx src/editor/backgroundFill.verify.ts && tsx --tsconfig tsconfig.app.json src/components/preview/previewTransform.verify.ts && tsx --tsconfig tsconfig.app.json src/components/inspector/background-fill-control.verify.tsx && tsx src/agent/tools/edit-item-background-fill.verify.ts && tsx src/export/fcpxml-background-fill.verify.ts",
-    "test:contrib-timeline-preview": "tsx --tsconfig tsconfig.app.json src/captions/captionSelection.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionSelectionInteraction.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionGroupMove.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionTimelineClipboard.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionCueContextMenu.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/useTimelinePointer.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineSeek.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineMixedSelectionIntegration.verify.ts && tsx --tsconfig tsconfig.app.json src/editor/editorDrag.verify.ts && tsx --tsconfig tsconfig.app.json src/media/externalFileDrop.verify.ts && tsx --tsconfig tsconfig.app.json src/editor/mediaAssetPlacement.verify.ts",
-    "verify:agent-skill": "node server/external-agent/external-skill.verify.mjs",
-    "verify:production-contracts": "tsx src/editor/transitionReconcile.verify.ts && tsx src/editor/overwrite.verify.ts && tsx src/editor/inspectorBatch.verify.ts && tsx src/editor/timelineViewState.verify.ts && tsx src/editor/slip.verify.ts && tsx src/components/timeline/useTimelinePointer.verify.ts && tsx src/components/timeline/libraryDropActions.verify.ts && tsx src/agent/tools/edit-item-slip.verify.ts && tsx src/agent/tools/edit-item-source-range.verify.ts && tsx src/geometry/geometry-math.verify.ts && tsx src/geometry/visual-geometry.verify.ts && tsx src/geometry/caption-collision.verify.ts && tsx src/captions/captionPagination.verify.ts && tsx src/agent/tools/captions-stable-refs.verify.ts && tsx src/reframe/geometry-focus.verify.ts && tsx src/geometry/placement.verify.ts && tsx src/agent/tools/edit-item-batch.verify.ts && tsx src/agent/tools/multicam-tools.verify.ts && tsx src/editor/mediaSourceRevision.verify.ts && tsx src/editor/mediaContentIdentity.verify.ts && tsx src/editor/mediaAssetUsage.verify.ts && tsx src/media/media-import-conflict.verify.ts && tsx src/media/uploadResponse.verify.ts && tsx src/persist/mediaBlobStore.verify.ts && tsx src/persist/projectTransfer.verify.ts && tsx src/export/backgroundExportStore.verify.ts && tsx src/media/mediaRelinkMatch.verify.ts && tsx src/multicam/timecodeSync.verify.ts && tsx src/multicam/professionalMulticam.verify.ts && tsx src/gl/selectedPreview.verify.ts && tsx src/editor/sequenceGraph.verify.ts && tsx src/editor/timecode.verify.ts && tsx src/agent/sceneQuality.verify.ts && tsx server/external-agent/mcp.verify.ts && tsx server/external-agent/offline-runtime.verify.ts && tsx server/external-agent/offline-project-store.verify.ts && tsx server/external-agent/offline-mcp.verify.ts && tsx server/external-agent/import-token.verify.ts && tsx server/plugins/external-agent.verify.ts && tsx src/agent/tools/stock-tools.verify.ts && tsx src/media/mobileImport.verify.ts",
-    "lint": "oxlint",
-    "preview": "vite preview",
-    "desktop:build:main": "esbuild desktop/main.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/main.mjs && esbuild desktop/native-asr-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-asr-worker.mjs && esbuild desktop/native-semantic-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-semantic-worker.mjs && esbuild desktop/native-clap-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-clap-worker.mjs && esbuild desktop/native-rhythm-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-rhythm-worker.mjs && esbuild desktop/preload.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=desktop-dist/preload.cjs",
-    "desktop:dev": "node scripts/dev-profile.mjs --exec npm run desktop:dev:shared",
-    "desktop:dev:shared": "npm run desktop:build:main && electron desktop-dist/main.mjs",
-    "desktop:smoke": "npm run desktop:build:main && CC_SMOKE=1 electron desktop-dist/main.mjs",
-    "desktop:prebundle": "tsx desktop/prebuild-remotion.mts",
-    "desktop:dist": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts darwin-arm64 && CC_EB_TARGET=darwin-arm64 electron-builder --config electron-builder.config.mjs --mac --arm64 --publish never",
-    "desktop:prepare": "tsx desktop/prepare-target.mts",
-    "desktop:dist:mac-x64": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts darwin-x64 && CC_EB_TARGET=darwin-x64 electron-builder --config electron-builder.config.mjs --mac --x64 --publish never",
-    "desktop:dist:win": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts win32-x64 && node -e \"const {spawnSync}=require('node:child_process');const result=spawnSync(process.execPath,['node_modules/electron-builder/cli.js','--config','electron-builder.config.mjs','--win','nsis','--x64','--publish','never'],{stdio:'inherit',env:{...process.env,CC_EB_TARGET:'win32-x64'}});if(result.error)throw result.error;process.exit(result.status??1)\"",
-    "desktop:dist:linux": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts linux-x64 && CC_EB_TARGET=linux-x64 electron-builder --config electron-builder.config.mjs --linux AppImage --x64 --publish never",
-    "verify:shortcuts": "tsx src/shortcuts/catalog.verify.ts && tsx src/shortcuts/keymap.verify.ts && tsx src/shortcuts/shortcutScope.verify.ts && tsx src/shortcuts/native-copy.verify.ts",
-    "verify:i18n": "node scripts/check-i18n.mjs",
-    "verify:editor": "tsx src/editor/keyframes.verify.ts && tsx src/editor/multiSelect.verify.ts && tsx src/editor/professionalTimeline.verify.ts && tsx src/editor/proposal.verify.ts && tsx src/editor/ripple-fade.verify.ts && tsx src/editor/ripple.verify.ts && tsx src/editor/split.verify.ts && tsx src/editor/transitionPreview.verify.ts && tsx src/editor/zoom.verify.ts && tsx src/editor/keyframes-check.verify.ts",
-    "verify:captions": "tsx src/captions/captionCueMenu.verify.ts && tsx src/captions/captionIdentity.verify.ts && tsx src/captions/exportCaptions.verify.ts && tsx src/captions/presetStore.verify.ts && tsx src/captions/renderStyles.verify.ts && tsx src/captions/segmenter.verify.ts && tsx src/captions/styles.verify.ts && tsx src/transcript/edit.verify.ts && tsx src/transcript/transcribe-jobs.verify.ts && tsx src/transcript/variants.verify.ts && tsx src/audio/loudness.verify.ts && tsx src/audio/vad.verify.ts && tsx src/transcript/transcribe-jobs-check.verify.ts",
-    "verify:agent-tools": "tsx src/agent/external-edit-session-apply.verify.ts && tsx src/agent/external-edit-session-cancellation.verify.ts && tsx src/agent/external-edit-session-core.verify.ts && tsx src/agent/external-edit-session-projection.verify.ts && tsx src/agent/external-edit-session-runtime.verify.ts && tsx src/agent/external-tool-policy.verify.ts && tsx src/agent/progress/job-model.verify.ts && tsx src/agent/progress/track-progress-targets.verify.ts && tsx src/agent/selection-refs.verify.ts && tsx src/agent/skills/plugin-skills.verify.ts && tsx src/agent/skills/skills-catalog.verify.ts && tsx src/agent/tools/agent-gap-p3.verify.ts && tsx src/agent/tools/audio-assets.verify.ts && tsx src/agent/tools/auto-grade-tools.verify.ts && tsx src/agent/tools/captions-lanes.verify.ts && tsx src/agent/tools/captions-tools.verify.ts && tsx src/agent/tools/design-tools.verify.ts && tsx src/agent/tools/edit-asset-tools.verify.ts && tsx src/agent/tools/edit-item-authored.verify.ts && tsx src/agent/tools/edit-item-generic.verify.ts && tsx src/agent/tools/edit-item-volume-hint.verify.ts && tsx src/agent/tools/export-tools.verify.ts && tsx src/agent/tools/followup-tools.verify.ts && tsx src/agent/tools/font-tools.verify.ts && tsx src/agent/tools/frames-tool.verify.ts && tsx src/agent/tools/friction-tools.verify.ts && tsx src/agent/tools/generate-rerun.verify.ts && tsx src/agent/tools/highlight-tool.verify.ts && tsx src/agent/tools/markers-tools.verify.ts && tsx src/agent/tools/media-pool-favorite-delete.verify.ts && tsx src/agent/tools/media-pool-relink.verify.ts && tsx src/agent/tools/media-pool-tools.verify.ts && tsx src/agent/tools/mg-code-tools.verify.ts && tsx src/agent/tools/mg-video-tools.verify.ts && tsx src/agent/tools/probe-tools.verify.ts && tsx src/agent/tools/project-tools.verify.ts && tsx src/agent/tools/followup-tools-check.verify.ts && tsx src/agent/tools/probe-tools-check.verify.ts && tsx src/agent/tools/read-project-tools-check.verify.ts && tsx src/agent/tools/stock-tools-check.verify.ts && tsx src/agent/tools/template-tools-check.verify.ts && node scripts/run-check.mjs src/agent/tools/effect-tools.verify.ts && node scripts/run-check.mjs src/agent/tools/library-edit-item.verify.ts && tsx src/agent/tools/read-project-tools.verify.ts && tsx src/agent/tools/shader-tools.verify.ts && tsx src/agent/tools/skill-tools.verify.ts && tsx src/agent/tools/transcript-clear-edits.verify.ts && tsx src/agent/tools/transcript-tools.verify.ts && tsx src/agent/tools/version-tools.verify.ts && tsx src/agent/tools/web-tools.verify.ts",
-    "verify:components": "tsx --tsconfig tsconfig.app.json src/components/SafeZoneOverlay.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/chat/chatPopoverGeometry.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/chatScrollNavigation.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/chatTextSelection.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/editorDragReference.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/message-groups.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/template-reference-localization.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/workflow-starters.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/inspector/inspectorPropSchemaLayout.verify.ts && tsx --tsconfig tsconfig.app.json src/components/inspector/inspectorTextArea.verify.ts && tsx --tsconfig tsconfig.app.json src/components/preview/preview-transform-overlay.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/preview/previewTextEdit.verify.ts && tsx --tsconfig tsconfig.app.json src/components/preview/timeline-hover-preview.verify.ts && tsx --tsconfig tsconfig.app.json src/components/previewAudioPool.verify.ts && tsx --tsconfig tsconfig.app.json src/components/settings/design-style-localization.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/clipContextSelection.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineChatDrop.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineWindow.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/trackContextOperations.verify.ts && tsx src/library/extension-installed.verify.ts && tsx src/library/library-card-grid.verify.ts && tsx src/library/resource-tabs-drag.verify.ts && tsx src/library/template-card-actions.verify.ts && tsx src/library/template-category-sticky.verify.ts && tsx src/components/chat/message-groups-check.verify.ts && tsx src/components/chat/widget-parse-check.verify.ts",
-    "verify:media-persist": "tsx --tsconfig tsconfig.app.json src/media/add-solid-canvas-card.verify.tsx && tsx src/media/asset-menu-destinations.verify.tsx && tsx src/media/assetExport.verify.ts && tsx src/media/media-aspect-badge.verify.ts && tsx src/media/media-favorites-folder.verify.ts && tsx src/media/media-folder-drop.verify.ts && tsx src/media/media-pool-progressive-import.verify.ts && tsx src/media/media-view-toggle.verify.ts && tsx src/media/mediaFolderDrop.verify.ts && tsx src/media/mediaMarquee.verify.ts && tsx src/media/mediaPoolShortcutScope.verify.ts && tsx src/media/mediaSelectionActions.verify.ts && tsx src/media/mgPreview.verify.ts && tsx src/media/searchMedia.verify.ts && tsx src/media/semantic-search/mediaFrames.verify.ts && tsx src/media/upload-session-recovery.verify.ts && tsx src/persist/agentRuntimeTransfer.verify.ts && tsx src/persist/chat-persist.verify.ts && tsx src/persist/exportHistoryStore.verify.ts && tsx src/persist/jobRegistryStore.verify.ts && tsx src/persist/mediaBlobStore.verify.ts && tsx src/persist/mediaCleanup.verify.ts && tsx src/persist/projectStore.verify.ts && tsx src/persist/projectTransfer.verify.ts && tsx src/persist/proposalStore.verify.ts && tsx src/persist/sessionPrefs.verify.ts && tsx src/persist/skillStore.verify.ts && tsx src/persist/template-recent.verify.ts && tsx src/persist/version-store.verify.ts && tsx src/persist/jobRegistryStore-check.verify.ts && tsx src/persist/mediaBlobStore-check.verify.ts && tsx src/persist/projectStore-check.verify.ts && tsx src/persist/projectTransfer-check.verify.ts",
-    "verify:export-gl": "tsx src/export/export-reliability.verify.ts && tsx src/export/exportMediaPlan.verify.ts && tsx src/export/range.verify.ts && tsx src/gl/customTransitions.verify.ts && tsx src/gl/fx/chroma-key.verify.ts && tsx src/gl/fx/cube.verify.ts && tsx src/gl/fx/fx.verify.ts && tsx src/gl/shader-contract.verify.ts && tsx src/generate/media-export.geometry.verify.ts && tsx src/generate/video.verify.ts && tsx src/plugins/export.verify.ts && tsx src/plugins/resourcePreview.verify.ts && tsx src/plugins/validate.verify.ts && tsx src/multicam/align.verify.ts && tsx src/multicam/sync.verify.ts && tsx src/reframe/detect.verify.ts && tsx src/script/script.verify.ts && tsx --tsconfig tsconfig.app.json src/fonts/notoSansOffline.verify.ts",
-    "verify:server-extra": "tsx server/media-normalization-admission.verify.ts && tsx server/plugins/firecrawl.verify.ts && tsx server/plugins/isolate-voice.verify.ts && tsx server/plugins/project-store-merge.verify.ts && tsx server/plugins/render-clip-cancellation.verify.ts && tsx server/plugins/storage-lifecycle.verify.ts && tsx server/plugins/video-reference.verify.ts && tsx server/safe-public-fetch.verify.ts && tsx shared/timeline-geometry.verify.ts && tsx remotion/render-timeout.verify.mjs && tsx server/plugins/stock-check.verify.ts",
-    "verify:sqlite-migration": "tsx server/storage/sqlite-store.verify.ts && tsx server/storage/sqlite-migration-http.verify.ts && tsx server/plugins/project-store-export-recovery-sqlite.verify.ts && tsx src/export/serverExportRecovery.verify.ts"
-  },
-  "dependencies": {
-    "@ai-sdk/alibaba": "^2.0.16",
-    "@ai-sdk/anthropic": "^4.0.16",
-    "@ai-sdk/cartesia": "^3.0.20",
-    "@ai-sdk/deepgram": "^3.0.25",
-    "@ai-sdk/deepseek": "^3.0.13",
-    "@ai-sdk/elevenlabs": "^3.0.26",
-    "@ai-sdk/google": "^4.0.24",
-    "@ai-sdk/groq": "^4.0.26",
-    "@ai-sdk/mistral": "^4.0.14",
-    "@ai-sdk/moonshotai": "^3.0.17",
-    "@ai-sdk/openai": "^4.0.16",
-    "@ai-sdk/openai-compatible": "^3.0.12",
-    "@aws-sdk/client-s3": "^3.1089.0",
-    "@aws-sdk/s3-request-presigner": "^3.1090.0",
-    "@babel/standalone": "^8.0.4",
-    "@e2b/code-interpreter": "^2.6.1",
-    "@ffprobe-installer/ffprobe": "^2.1.2",
-    "@huggingface/transformers": "^3.8.1",
-    "@mediapipe/tasks-vision": "^1.0.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "@remotion/bundler": "4.0.489",
-    "@remotion/google-fonts": "^4.0.489",
-    "@remotion/media": "4.0.489",
-    "@remotion/player": "^4.0.489",
-    "@remotion/renderer": "4.0.489",
-    "@remotion/web-renderer": "4.0.489",
-    "@smithy/node-http-handler": "^4.9.7",
-    "ai": "^7.0.31",
-    "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1",
-    "electron-updater": "^6.8.9",
-    "ffmpeg-static": "^5.3.0",
-    "heic-to": "^1.5.2",
-    "https-proxy-agent": "^9.1.0",
-    "jieba-wasm": "^2.4.0",
-    "onnxruntime-node": "1.22.0",
-    "qrcode": "^1.5.4",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
-    "remotion": "^4.0.489",
-    "sqlite-vec": "^0.1.9"
-  },
-  "devDependencies": {
-    "@types/babel__standalone": "^7.1.9",
-    "@types/node": "^24.13.2",
-    "@types/qrcode": "^1.5.6",
-    "@types/react": "^19.2.17",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.3",
-    "electron": "^43.1.1",
-    "electron-builder": "^26.15.3",
-    "esbuild": "^0.28.1",
-    "oxlint": "^1.71.0",
-    "tsx": "^4.23.1",
-    "typescript": "~6.0.2",
-    "typescript-language-server": "^5.3.0",
-    "vite": "^8.1.1"
+    "test:contrib-timeline-preview": "tsx --tsconfig tsconfig.app.json src/capëo|¶‰žËkºwµçit access(path, constants.R_OK);
+    return (await stat(path)).isFile();
+  } catch {
+    return false;
   }
+}
+
+function issueFor(reference: ExportMediaReference, code: ExportMediaIssue['code'], message: string): ExportMediaIssue {
+  return { ...reference, code, message };
+}
+
+function isHtmlContentType(contentType: string | null | undefined): boolean {
+  return contentType?.split(';', 1)[0]?.trim().toLowerCase() === 'text/html';
+}
+
+function extensionFor(source: string, contentType: string | null): string {
+  const mime = contentType?.split(';', 1)[0]?.trim().toLowerCase() ?? '';
+  const mimeExtension = MIME_EXTENSIONS[mime];
+  if (mimeExtension) return mimeExtension;
+  try {
+    const extension = extname(new URL(source).pathname).toLowerCase();
+    if (/^\.(?:aac|avif|bin|cube|flac|gif|heic|jpe?g|m4a|m4v|mov|mp3|mp4|ogg|opus|png|svg|wav|webm|webp)$/.test(extension)) {
+      return extension;
+    }
+  } catch {
+    // safePublicFetch already validated the URL; use a neutral extension.
+  }
+  return '.bin';
+}
+
+async function cleanupPaths(paths: readonly string[]): Promise<void> {
+  await Promise.all(paths.map(async (path) => {
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      try {
+        await unlink(path);
+        return;
+      } catch (error) {
+        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return;
+        if (attempt === 4) throw error;
+        await delay(25 * 2 ** attempt);
+      }
+    }
+  }));
+}
+
+async function materializeRemote(
+  reference: ExportMediaReference,
+  options: ResolvedServerExportMediaOptions,
+): Promise<{ localPath: string; publicPath: string } | ExportMediaIssue> {
+  let response: Response | undefined;
+  let partialPath: string | undefined;
+  let finalPath: string | undefined;
+  let handle: FileHandle | undefined;
+  let completed = false;
+  const timeoutSignal = AbortSignal.timeout(30 * 60_000);
+  const fetchSignal = options.signal
+    ? AbortSignal.any([options.signal, timeoutSignal])
+    : timeoutSignal;
+  try {
+    fetchSignal.throwIfAborted();
+    response = await options.fetcher(reference.source, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: fetchSignal,
+    });
+    fetchSignal.throwIfAborted();
+    const contentType = response.headers.get('content-type');
+    if (isHtmlContentType(contentType)) {
+      return issueFor(
+        reference,
+        'missing_source',
+        `Media source resolved to HTML instead of media (HTTP ${response.status}): ${reference.source}`,
+      );
+    }
+    if (response.status !== 200 || !response.body) {
+      return issueFor(
+        reference,
+        response.status === 404 ? 'missing_source' : 'unreadable',
+        `Media source is not readable (HTTP ${response.status}): ${reference.source}`,
+      );
+    }
+    const declaredLength = Number(response.headers.get('content-length'));
+    if (Number.isFinite(declaredLength) && declaredLength > options.maxMaterializedBytes) {
+      return issueFor(reference, 'unreadable', `Media source exceeds the materialization limit: ${reference.source}`);
+    }
+
+    await mkdir(options.uploadDirectory, { recursive: true });
+    fetchSignal.throwIfAborted();
+    const filename = `openchatcut-render-media-${randomUUID()}${extensionFor(reference.source, contentType)}`;
+    finalPath = resolve(options.uploadDirectory, filename);
+    partialPath = `${finalPath}.part`;
+    handle = await open(partialPath, 'wx', 0o600);
+    fetchSignal.throwIfAborted();
+    const reader = response.body.getReader();
+    let bytes = 0;
+    try {
+      for (;;) {
+        fetchSignal.throwIfAborted();
+        const { done, value } = await reader.read();
+        fetchSignal.throwIfAborted();
+        if (done) break;
+        bytes += value.byteLength;
+        if (bytes > options.maxMaterializedBytes) {
+          throw new Error(`Media source exceeds the materialization limit: ${reference.source}`);
+        }
+        let offset = 0;
+        while (offset < value.byteLength) {
+          fetchSignal.throwIfAborted();
+          const { bytesWritten } = await handle.write(value.subarray(offset));
+          fetchSignal.throwIfAborted();
+          if (bytesWritten < 1) throw new Error(`Media source could not be written: ${reference.source}`);
+          offset += bytesWritten;
+        }
+      }
+    } catch (error) {
+      await reader.cancel(error).catch(() => undefined);
+      throw error;
+    }
+    if (bytes < 1) throw new Error(`Media source returned an empty body: ${reference.source}`);
+    await handle.sync();
+    fetchSignal.throwIfAborted();
+    await handle.close();
+    handle = undefined;
+    fetchSignal.throwIfAborted();
+    await rename(partialPath, finalPath);
+    partialPath = undefined;
+    fetchSignal.throwIfAborted();
+    completed = true;
+    return { localPath: finalPath, publicPath: `/media/uploads/${filename}` };
+  } catch (error) {
+    options.signal?.throwIfAborted();
+    return issueFor(
+      reference,
+      'unreadable',
+      `Media source could not be materialized: ${reference.source} (${error instanceof Error ? error.message : String(error)})`,
+    );
+  } finally {
+    await response?.body?.cancel().catch(() => undefined);
+    await handle?.close().catch(() => undefined);
+    if (partialPath) await unlink(partialPath).catch(() => undefined);
+    if (finalPath && !completed) await unlink(finalPath).catch(() => undefined);
+  }
+}
+
+async function checkLocalReference(
+  reference: ExportMediaReference,
+  options: ResolvedServerExportMediaOptions,
+): Promise<ExportMediaIssue | null> {
+  options.signal?.throwIfAborted();
+  if (reference.source.startsWith('data:')) return null;
+  if (reference.source.startsWith('blob:')) {
+    return issueFor(reference, 'unsupported_source', `Blob URL is not readable by the export server: ${reference.source}`);
+  }
+  if (reference.source.startsWith('file:') || isAbsolute(reference.source) && !reference.source.startsWith('/')) {
+    return issueFor(reference, 'unsupported_source', `Local file source is not mapped for export: ${reference.source}`);
+  }
+
+  const rawPathname = reference.source.split(/[?#]/, 1)[0] ?? '';
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(rawPathname);
+  } catch {
+    return issueFor(reference, 'unsupported_source', `Media source has invalid path encoding: ${reference.source}`);
+  }
+  const uploadPrefix = '/media/uploads/';
+  if (pathname.startsWith(uploadPrefix)) {
+    const name = pathname.slice(uploadPrefix.length);
+    if (!isSafeUploadName(name)) {
+      return issueFor(reference, 'unsupported_source', `Media upload name is unsafe: ${reference.source}`);
+    }
+    const local = options.resolveUpload(name);
+    if (local) {
+      const readable = await readableFile(local);
+      options.signal?.throwIfAborted();
+      return readable
+        ? null
+        : issueFor(reference, 'unreadable', `Media upload is not readable: ${reference.source}`);
+    }
+    let hydrated: ResolvedUploadFile | null;
+    try {
+      hydrated = await options.hydrateUpload(name, options.signal);
+      options.signal?.throwIfAborted();
+    } catch (error) {
+      options.signal?.throwIfAborted();
+      return issueFor(
+        reference,
+        'unreadable',
+        `Media upload could not be restored: ${reference.source} (${error instanceof Error ? error.message : String(error)})`,
+      );
+    }
+    if (!hydrated) return issueFor(reference, 'missing_source', `Media upload is missing: ${reference.source}`);
+    if (isHtmlContentType(hydrated.contentType)) {
+      return issueFor(reference, 'missing_source', `Media upload resolved to HTML instead of media: ${reference.source}`);
+    }
+    const readable = await readableFile(hydrated.file);
+    options.signal?.throwIfAborted();
+    return readable
+      ? null
+      : issueFor(reference, 'unreadable', `Restored media upload is not readable: ${reference.source}`);
+  }
+  if (!pathname.startsWith('/')) {
+    return issueFor(reference, 'unsupported_source', `Relative media source is not mapped for export: ${reference.source}`);
+  }
+  const candidate = resolve(options.publicDirectory, `.${pathname}`);
+  const escaped = relative(options.publicDirectory, candidate);
+  if (escaped === '..' || escaped.startsWith(`..${sep}`) || isAbsolute(escaped)) {
+    return issueFor(reference, 'unsupported_source', `Media source escapes the public directory: ${reference.source}`);
+  }
+  const readable = await readableFile(candidate);
+  options.signal?.throwIfAborted();
+  if (readable) return null;
+
+  // Product-bundled media is served at the same root-absolute URL paths as
+  // public media by productAssetsPlugin. Keep this lookup behind the same
+  // resolver so export preflight and the static renderer agree on disk layout.
+  const productAsset = resolveProductAsset(rawPathname);
+  const productReadable = productAsset ? await readableFile(productAsset) : false;
+  options.signal?.throwIfAborted();
+  return productReadable
+    ? null
+    : issueFor(reference, 'missing_source', `Public or product media source is missing or unreadable: ${reference.source}`);
+}
+
+
+function replaceMaterializedSources(value: unknown, replacements: ReadonlyMap<string, string>, seen: WeakSet<object>): void {
+  if (value === null || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const child = value[index];
+      if (typeof child === 'string') value[index] = replacements.get(child) ?? child;
+      else replaceMaterializedSources(child, replacements, seen);
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (typeof child === 'string') {
+      if (replacements.has(child)) Reflect.set(value, key, replacements.get(child));
+    } else {
+      replaceMaterializedSources(child, replacements, seen);
+    }
+  }
+}
+
+function freezeSnapshot(value: unknown, seen: WeakSet<object>): void {
+  if (value === null || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+  for (const child of Object.values(value)) freezeSnapshot(child, seen);
+  Object.freeze(value);
+}
+
+function resolvedOptions(options: ServerExportMediaOptions): ResolvedServerExportMediaOptions {
+  const requestedLimit = options.maxMaterializedBytes;
+  const maxMaterializedBytes = typeof requestedLimit === 'number'
+    && Number.isFinite(requestedLimit)
+    && requestedLimit > 0
+    ? Math.floor(requestedLimit)
+    : MAX_MATERIALIZED_MEDIA_BYTES;
+  return {
+    publicDirectory: resolve(options.publicDirectory ?? resolve(process.cwd(), 'public')),
+    uploadDirectory: resolve(options.uploadDirectory ?? uploadDir()),
+    fetcher: options.fetcher ?? safePublicFetch,
+    resolveUpload: options.resolveUpload ?? resolveUploadFile,
+    hydrateUpload: options.hydrateUpload
+      ?? ((name, signal) => resolveOrHydrateUploadFile(name, undefined, signal)),
+    maxMaterializedBytes,
+    signal: options.signal,
+  };
+}
+
+function preflightFailure(issues: readonly ExportMediaIssue[]): ExportFailureError {
+  const detail = issues.map((issue) => `${issue.code}: ${issue.source}${issue.message ? ` (${issue.message})` : ''}`).join('; ');
+  return new ExportFailureError(createExportFailure({
+    stage: 'preflight',
+    code: 'export_media_preflight_failed',
+    retryable: false,
+    message: `Export media preflight failed for ${issues.length} reference${issues.length === 1 ? '' : 's'}: ${detail}`,
+    mediaIssues: [...issues],
+  }));
+}
+
+/**
+ * Resolve every render-visible external URL exactly once through safePublicFetch,
+ * atomically publish it under the controlled upload directory, and freeze a
+ * snapshot whose renderer-visible references are same-origin paths.
+ */
+export async function materializeServerExportMedia<Value>(
+  snapshot: Value,
+  options: ServerExportMediaOptions = {},
+): Promise<MaterializedServerExportMedia<Value>> {
+  options.signal?.throwIfAborted();
+  const plan = collectExportMediaPlan(snapshot);
+  options.signal?.throwIfAborted();
+  if (plan.issues.length > 0) throw preflightFailure(plan.issues);
+  const resolved = resolvedOptions(options);
+  const remoteReferences = plan.references.filter((reference) => /^https?:\/\//i.test(reference.source));
+  const localReferences = plan.references.filter((reference) => !/^https?:\/\//i.test(reference.source));
+  const replacements = new Map<string, string>();
+  const localPaths: string[] = [];
+  try {
+    const localIssues = (await Promise.all(
+      localReferences.map((reference) => checkLocalReference(reference, resolved)),
+    )).filter((issue): issue is ExportMediaIssue => issue !== null);
+    resolved.signal?.throwIfAborted();
+    if (localIssues.length > 0) throw preflightFailure(localIssues);
+
+    const remoteIssues: ExportMediaIssue[] = [];
+    const attemptedRemoteSources = new Set<string>();
+    for (const reference of remoteReferences) {
+      resolved.signal?.throwIfAborted();
+      if (attemptedRemoteSources.has(reference.source)) continue;
+      attemptedRemoteSources.add(reference.source);
+      const materialized = await materializeRemote(reference, resolved);
+      if ('code' in materialized) {
+        resolved.signal?.throwIfAborted();
+        remoteIssues.push(materialized);
+        continue;
+      }
+      replacements.set(reference.source, materialized.publicPath);
+      localPaths.push(materialized.localPath);
+      resolved.signal?.throwIfAborted();
+    }
+    if (remoteIssues.length > 0) throw preflightFailure(remoteIssues);
+
+    resolved.signal?.throwIfAborted();
+    const immutable = structuredClone(snapshot);
+    replaceMaterializedSources(immutable, replacements, new WeakSet());
+    freezeSnapshot(immutable, new WeakSet());
+    resolved.signal?.throwIfAborted();
+    let cleanupPromise: Promise<void> | undefined;
+    return Object.freeze({
+      snapshot: immutable,
+      plan,
+      localPaths: Object.freeze([...localPaths]),
+      cleanup: () => cleanupPromise ??= cleanupPaths(localPaths),
+    });
+  } catch (error) {
+    await cleanupPaths(localPaths);
+    throw error;
+  }
+}
+
+export async function validateServerExportMedia(
+  snapshot: unknown,
+  options: ServerExportMediaOptions = {},
+): Promise<ExportMediaPlan> {
+  const materialized = await materializeServerExportMedia(snapshot, options);
+  await materialized.cleanup();
+  return materialized.plan;
 }

--- a/package.json
+++ b/package.json
@@ -51,353 +51,91 @@
     "posttest": "npm run verify:background-fill && npm run verify:speech-providers && npm run verify:desktop-worker-lifecycle && npm run verify:server-runs",
     "verify:server-runs": "tsx server/agent-runs/tool-catalog-generation.verify.ts && tsx server/agent-runs/executor.verify.ts && tsx server/agent-runs/tool-policy.verify.ts && tsx server/agent-runs/store.verify.ts && tsx server/agent-runs/store-approval.verify.ts && tsx server/agent-runs/store-capability.verify.ts && tsx server/agent-runs/routes.verify.ts && tsx src/agent/useServerRun.verify.ts && tsx src/agent/serverRunFetchEventStream.verify.ts && tsx src/agent/serverRunSessionStorage.verify.ts && tsx src/agent/serverRunModelHistory.verify.ts && tsx src/agent/serverRunOwnership.verify.ts && tsx src/agent/serverRunToolExecutor.verify.ts && tsx src/agent/serverRunToolRecovery.verify.ts && tsx src/agent/useAgentHistoryActions.verify.ts && tsx src/components/chat/serverRunInspector.verify.ts",
     "verify:background-fill": "tsx src/editor/backgroundFill.verify.ts && tsx --tsconfig tsconfig.app.json src/components/preview/previewTransform.verify.ts && tsx --tsconfig tsconfig.app.json src/components/inspector/background-fill-control.verify.tsx && tsx src/agent/tools/edit-item-background-fill.verify.ts && tsx src/export/fcpxml-background-fill.verify.ts",
-    "test:contrib-timeline-preview": "tsx --tsconfig tsconfig.app.json src/capëo|¶‰žËkºwµçit access(path, constants.R_OK);
-    return (await stat(path)).isFile();
-  } catch {
-    return false;
+    "test:contrib-timeline-preview": "tsx --tsconfig tsconfig.app.json src/captions/captionSelection.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionSelectionInteraction.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionGroupMove.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionTimelineClipboard.verify.ts && tsx --tsconfig tsconfig.app.json src/captions/captionCueContextMenu.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/useTimelinePointer.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineSeek.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineMixedSelectionIntegration.verify.ts && tsx --tsconfig tsconfig.app.json src/editor/editorDrag.verify.ts && tsx --tsconfig tsconfig.app.json src/media/externalFileDrop.verify.ts && tsx --tsconfig tsconfig.app.json src/editor/mediaAssetPlacement.verify.ts",
+    "verify:agent-skill": "node server/external-agent/external-skill.verify.mjs",
+    "verify:production-contracts": "tsx src/editor/transitionReconcile.verify.ts && tsx src/editor/overwrite.verify.ts && tsx src/editor/inspectorBatch.verify.ts && tsx src/editor/timelineViewState.verify.ts && tsx src/editor/slip.verify.ts && tsx src/components/timeline/useTimelinePointer.verify.ts && tsx src/components/timeline/libraryDropActions.verify.ts && tsx src/agent/tools/edit-item-slip.verify.ts && tsx src/agent/tools/edit-item-source-range.verify.ts && tsx src/geometry/geometry-math.verify.ts && tsx src/geometry/visual-geometry.verify.ts && tsx src/geometry/caption-collision.verify.ts && tsx src/captions/captionPagination.verify.ts && tsx src/agent/tools/captions-stable-refs.verify.ts && tsx src/reframe/geometry-focus.verify.ts && tsx src/geometry/placement.verify.ts && tsx src/agent/tools/edit-item-batch.verify.ts && tsx src/agent/tools/multicam-tools.verify.ts && tsx src/editor/mediaSourceRevision.verify.ts && tsx src/editor/mediaContentIdentity.verify.ts && tsx src/editor/mediaAssetUsage.verify.ts && tsx src/media/media-import-conflict.verify.ts && tsx src/media/uploadResponse.verify.ts && tsx src/persist/mediaBlobStore.verify.ts && tsx src/persist/projectTransfer.verify.ts && tsx src/export/backgroundExportStore.verify.ts && tsx src/media/mediaRelinkMatch.verify.ts && tsx src/multicam/timecodeSync.verify.ts && tsx src/multicam/professionalMulticam.verify.ts && tsx src/gl/selectedPreview.verify.ts && tsx src/editor/sequenceGraph.verify.ts && tsx src/editor/timecode.verify.ts && tsx src/agent/sceneQuality.verify.ts && tsx server/external-agent/mcp.verify.ts && tsx server/external-agent/offline-runtime.verify.ts && tsx server/external-agent/offline-project-store.verify.ts && tsx server/external-agent/offline-mcp.verify.ts && tsx server/external-agent/import-token.verify.ts && tsx server/plugins/external-agent.verify.ts && tsx src/agent/tools/stock-tools.verify.ts && tsx src/media/mobileImport.verify.ts",
+    "lint": "oxlint",
+    "preview": "vite preview",
+    "desktop:build:main": "esbuild desktop/main.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/main.mjs && esbuild desktop/native-asr-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-asr-worker.mjs && esbuild desktop/native-semantic-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-semantic-worker.mjs && esbuild desktop/native-clap-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-clap-worker.mjs && esbuild desktop/native-rhythm-worker.ts --bundle --platform=node --format=esm --packages=external --sourcemap --outfile=desktop-dist/native-rhythm-worker.mjs && esbuild desktop/preload.ts --bundle --platform=node --format=cjs --packages=external --sourcemap --outfile=desktop-dist/preload.cjs",
+    "desktop:dev": "node scripts/dev-profile.mjs --exec npm run desktop:dev:shared",
+    "desktop:dev:shared": "npm run desktop:build:main && electron desktop-dist/main.mjs",
+    "desktop:smoke": "npm run desktop:build:main && CC_SMOKE=1 electron desktop-dist/main.mjs",
+    "desktop:prebundle": "tsx desktop/prebuild-remotion.mts",
+    "desktop:dist": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts darwin-arm64 && CC_EB_TARGET=darwin-arm64 electron-builder --config electron-builder.config.mjs --mac --arm64 --publish never",
+    "desktop:prepare": "tsx desktop/prepare-target.mts",
+    "desktop:dist:mac-x64": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts darwin-x64 && CC_EB_TARGET=darwin-x64 electron-builder --config electron-builder.config.mjs --mac --x64 --publish never",
+    "desktop:dist:win": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts win32-x64 && node -e \"const {spawnSync}=require('node:child_process');const result=spawnSync(process.execPath,['node_modules/electron-builder/cli.js','--config','electron-builder.config.mjs','--win','nsis','--x64','--publish','never'],{stdio:'inherit',env:{...process.env,CC_EB_TARGET:'win32-x64'}});if(result.error)throw result.error;process.exit(result.status??1)\"",
+    "desktop:dist:linux": "npm run build && npm run desktop:build:main && npm run desktop:prebundle && tsx desktop/prepare-target.mts linux-x64 && CC_EB_TARGET=linux-x64 electron-builder --config electron-builder.config.mjs --linux AppImage --x64 --publish never",
+    "verify:shortcuts": "tsx src/shortcuts/catalog.verify.ts && tsx src/shortcuts/keymap.verify.ts && tsx src/shortcuts/shortcutScope.verify.ts && tsx src/shortcuts/native-copy.verify.ts",
+    "verify:i18n": "node scripts/check-i18n.mjs",
+    "verify:editor": "tsx src/editor/keyframes.verify.ts && tsx src/editor/multiSelect.verify.ts && tsx src/editor/professionalTimeline.verify.ts && tsx src/editor/proposal.verify.ts && tsx src/editor/ripple-fade.verify.ts && tsx src/editor/ripple.verify.ts && tsx src/editor/split.verify.ts && tsx src/editor/transitionPreview.verify.ts && tsx src/editor/zoom.verify.ts && tsx src/editor/keyframes-check.verify.ts",
+    "verify:captions": "tsx src/captions/captionCueMenu.verify.ts && tsx src/captions/captionIdentity.verify.ts && tsx src/captions/exportCaptions.verify.ts && tsx src/captions/presetStore.verify.ts && tsx src/captions/renderStyles.verify.ts && tsx src/captions/segmenter.verify.ts && tsx src/captions/styles.verify.ts && tsx src/transcript/edit.verify.ts && tsx src/transcript/transcribe-jobs.verify.ts && tsx src/transcript/variants.verify.ts && tsx src/audio/loudness.verify.ts && tsx src/audio/vad.verify.ts && tsx src/transcript/transcribe-jobs-check.verify.ts",
+    "verify:agent-tools": "tsx src/agent/external-edit-session-apply.verify.ts && tsx src/agent/external-edit-session-cancellation.verify.ts && tsx src/agent/external-edit-session-core.verify.ts && tsx src/agent/external-edit-session-projection.verify.ts && tsx src/agent/external-edit-session-runtime.verify.ts && tsx src/agent/external-tool-policy.verify.ts && tsx src/agent/progress/job-model.verify.ts && tsx src/agent/progress/track-progress-targets.verify.ts && tsx src/agent/selection-refs.verify.ts && tsx src/agent/skills/plugin-skills.verify.ts && tsx src/agent/skills/skills-catalog.verify.ts && tsx src/agent/tools/agent-gap-p3.verify.ts && tsx src/agent/tools/audio-assets.verify.ts && tsx src/agent/tools/auto-grade-tools.verify.ts && tsx src/agent/tools/captions-lanes.verify.ts && tsx src/agent/tools/captions-tools.verify.ts && tsx src/agent/tools/design-tools.verify.ts && tsx src/agent/tools/edit-asset-tools.verify.ts && tsx src/agent/tools/edit-item-authored.verify.ts && tsx src/agent/tools/edit-item-generic.verify.ts && tsx src/agent/tools/edit-item-volume-hint.verify.ts && tsx src/agent/tools/export-tools.verify.ts && tsx src/agent/tools/followup-tools.verify.ts && tsx src/agent/tools/font-tools.verify.ts && tsx src/agent/tools/frames-tool.verify.ts && tsx src/agent/tools/friction-tools.verify.ts && tsx src/agent/tools/generate-rerun.verify.ts && tsx src/agent/tools/highlight-tool.verify.ts && tsx src/agent/tools/markers-tools.verify.ts && tsx src/agent/tools/media-pool-favorite-delete.verify.ts && tsx src/agent/tools/media-pool-relink.verify.ts && tsx src/agent/tools/media-pool-tools.verify.ts && tsx src/agent/tools/mg-code-tools.verify.ts && tsx src/agent/tools/mg-video-tools.verify.ts && tsx src/agent/tools/probe-tools.verify.ts && tsx src/agent/tools/project-tools.verify.ts && tsx src/agent/tools/followup-tools-check.verify.ts && tsx src/agent/tools/probe-tools-check.verify.ts && tsx src/agent/tools/read-project-tools-check.verify.ts && tsx src/agent/tools/stock-tools-check.verify.ts && tsx src/agent/tools/template-tools-check.verify.ts && node scripts/run-check.mjs src/agent/tools/effect-tools.verify.ts && node scripts/run-check.mjs src/agent/tools/library-edit-item.verify.ts && tsx src/agent/tools/read-project-tools.verify.ts && tsx src/agent/tools/shader-tools.verify.ts && tsx src/agent/tools/skill-tools.verify.ts && tsx src/agent/tools/transcript-clear-edits.verify.ts && tsx src/agent/tools/transcript-tools.verify.ts && tsx src/agent/tools/version-tools.verify.ts && tsx src/agent/tools/web-tools.verify.ts",
+    "verify:components": "tsx --tsconfig tsconfig.app.json src/components/SafeZoneOverlay.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/chat/chatPopoverGeometry.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/chatScrollNavigation.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/chatTextSelection.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/editorDragReference.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/message-groups.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/template-reference-localization.verify.ts && tsx --tsconfig tsconfig.app.json src/components/chat/workflow-starters.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/inspector/inspectorPropSchemaLayout.verify.ts && tsx --tsconfig tsconfig.app.json src/components/inspector/inspectorTextArea.verify.ts && tsx --tsconfig tsconfig.app.json src/components/preview/preview-transform-overlay.verify.tsx && tsx --tsconfig tsconfig.app.json src/components/preview/previewTextEdit.verify.ts && tsx --tsconfig tsconfig.app.json src/components/preview/timeline-hover-preview.verify.ts && tsx --tsconfig tsconfig.app.json src/components/previewAudioPool.verify.ts && tsx --tsconfig tsconfig.app.json src/components/settings/design-style-localization.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/clipContextSelection.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineChatDrop.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/timelineWindow.verify.ts && tsx --tsconfig tsconfig.app.json src/components/timeline/trackContextOperations.verify.ts && tsx src/library/extension-installed.verify.ts && tsx src/library/library-card-grid.verify.ts && tsx src/library/resource-tabs-drag.verify.ts && tsx src/library/template-card-actions.verify.ts && tsx src/library/template-category-sticky.verify.ts && tsx src/components/chat/message-groups-check.verify.ts && tsx src/components/chat/widget-parse-check.verify.ts",
+    "verify:media-persist": "tsx --tsconfig tsconfig.app.json src/media/add-solid-canvas-card.verify.tsx && tsx src/media/asset-menu-destinations.verify.tsx && tsx src/media/assetExport.verify.ts && tsx src/media/media-aspect-badge.verify.ts && tsx src/media/media-favorites-folder.verify.ts && tsx src/media/media-folder-drop.verify.ts && tsx src/media/media-pool-progressive-import.verify.ts && tsx src/media/media-view-toggle.verify.ts && tsx src/media/mediaFolderDrop.verify.ts && tsx src/media/mediaMarquee.verify.ts && tsx src/media/mediaPoolShortcutScope.verify.ts && tsx src/media/mediaSelectionActions.verify.ts && tsx src/media/mgPreview.verify.ts && tsx src/media/searchMedia.verify.ts && tsx src/media/semantic-search/mediaFrames.verify.ts && tsx src/media/upload-session-recovery.verify.ts && tsx src/persist/agentRuntimeTransfer.verify.ts && tsx src/persist/chat-persist.verify.ts && tsx src/persist/exportHistoryStore.verify.ts && tsx src/persist/jobRegistryStore.verify.ts && tsx src/persist/mediaBlobStore.verify.ts && tsx src/persist/mediaCleanup.verify.ts && tsx src/persist/projectStore.verify.ts && tsx src/persist/projectTransfer.verify.ts && tsx src/persist/proposalStore.verify.ts && tsx src/persist/sessionPrefs.verify.ts && tsx src/persist/skillStore.verify.ts && tsx src/persist/template-recent.verify.ts && tsx src/persist/version-store.verify.ts && tsx src/persist/jobRegistryStore-check.verify.ts && tsx src/persist/mediaBlobStore-check.verify.ts && tsx src/persist/projectStore-check.verify.ts && tsx src/persist/projectTransfer-check.verify.ts",
+    "verify:export-gl": "tsx src/export/export-reliability.verify.ts && tsx src/export/exportMediaPlan.verify.ts && tsx src/export/range.verify.ts && tsx src/gl/customTransitions.verify.ts && tsx src/gl/fx/chroma-key.verify.ts && tsx src/gl/fx/cube.verify.ts && tsx src/gl/fx/fx.verify.ts && tsx src/gl/shader-contract.verify.ts && tsx src/generate/media-export.geometry.verify.ts && tsx src/generate/video.verify.ts && tsx src/plugins/export.verify.ts && tsx src/plugins/resourcePreview.verify.ts && tsx src/plugins/validate.verify.ts && tsx src/multicam/align.verify.ts && tsx src/multicam/sync.verify.ts && tsx src/reframe/detect.verify.ts && tsx src/script/script.verify.ts && tsx --tsconfig tsconfig.app.json src/fonts/notoSansOffline.verify.ts",
+    "verify:server-extra": "tsx server/media-normalization-admission.verify.ts && tsx server/plugins/firecrawl.verify.ts && tsx server/plugins/isolate-voice.verify.ts && tsx server/plugins/project-store-merge.verify.ts && tsx server/plugins/render-clip-cancellation.verify.ts && tsx server/plugins/storage-lifecycle.verify.ts && tsx server/plugins/video-reference.verify.ts && tsx server/safe-public-fetch.verify.ts && tsx shared/timeline-geometry.verify.ts && tsx remotion/render-timeout.verify.mjs && tsx server/plugins/stock-check.verify.ts",
+    "verify:sqlite-migration": "tsx server/storage/sqlite-store.verify.ts && tsx server/storage/sqlite-migration-http.verify.ts && tsx server/plugins/project-store-export-recovery-sqlite.verify.ts && tsx src/export/serverExportRecovery.verify.ts"
+  },
+  "dependencies": {
+    "@ai-sdk/alibaba": "^2.0.16",
+    "@ai-sdk/anthropic": "^4.0.16",
+    "@ai-sdk/cartesia": "^3.0.20",
+    "@ai-sdk/deepgram": "^3.0.25",
+    "@ai-sdk/deepseek": "^3.0.13",
+    "@ai-sdk/elevenlabs": "^3.0.26",
+    "@ai-sdk/google": "^4.0.24",
+    "@ai-sdk/groq": "^4.0.26",
+    "@ai-sdk/mistral": "^4.0.14",
+    "@ai-sdk/moonshotai": "^3.0.17",
+    "@ai-sdk/openai": "^4.0.16",
+    "@ai-sdk/openai-compatible": "^3.0.12",
+    "@aws-sdk/client-s3": "^3.1089.0",
+    "@aws-sdk/s3-request-presigner": "^3.1090.0",
+    "@babel/standalone": "^8.0.4",
+    "@e2b/code-interpreter": "^2.6.1",
+    "@ffprobe-installer/ffprobe": "^2.1.2",
+    "@huggingface/transformers": "^3.8.1",
+    "@mediapipe/tasks-vision": "^1.0.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@remotion/bundler": "4.0.489",
+    "@remotion/google-fonts": "^4.0.489",
+    "@remotion/media": "4.0.489",
+    "@remotion/player": "^4.0.489",
+    "@remotion/renderer": "4.0.489",
+    "@remotion/web-renderer": "4.0.489",
+    "@smithy/node-http-handler": "^4.9.7",
+    "ai": "^7.0.31",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
+    "electron-updater": "^6.8.9",
+    "ffmpeg-static": "^5.3.0",
+    "heic-to": "^1.5.2",
+    "https-proxy-agent": "^9.1.0",
+    "jieba-wasm": "^2.4.0",
+    "onnxruntime-node": "1.22.0",
+    "qrcode": "^1.5.4",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
+    "remotion": "^4.0.489",
+    "sqlite-vec": "^0.1.9"
+  },
+  "devDependencies": {
+    "@types/babel__standalone": "^7.1.9",
+    "@types/node": "^24.13.2",
+    "@types/qrcode": "^1.5.6",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "electron": "^43.1.1",
+    "electron-builder": "^26.15.3",
+    "esbuild": "^0.28.1",
+    "oxlint": "^1.71.0",
+    "tsx": "^4.23.1",
+    "typescript": "~6.0.2",
+    "typescript-language-server": "^5.3.0",
+    "vite": "^8.1.1"
   }
-}
-
-function issueFor(reference: ExportMediaReference, code: ExportMediaIssue['code'], message: string): ExportMediaIssue {
-  return { ...reference, code, message };
-}
-
-function isHtmlContentType(contentType: string | null | undefined): boolean {
-  return contentType?.split(';', 1)[0]?.trim().toLowerCase() === 'text/html';
-}
-
-function extensionFor(source: string, contentType: string | null): string {
-  const mime = contentType?.split(';', 1)[0]?.trim().toLowerCase() ?? '';
-  const mimeExtension = MIME_EXTENSIONS[mime];
-  if (mimeExtension) return mimeExtension;
-  try {
-    const extension = extname(new URL(source).pathname).toLowerCase();
-    if (/^\.(?:aac|avif|bin|cube|flac|gif|heic|jpe?g|m4a|m4v|mov|mp3|mp4|ogg|opus|png|svg|wav|webm|webp)$/.test(extension)) {
-      return extension;
-    }
-  } catch {
-    // safePublicFetch already validated the URL; use a neutral extension.
-  }
-  return '.bin';
-}
-
-async function cleanupPaths(paths: readonly string[]): Promise<void> {
-  await Promise.all(paths.map(async (path) => {
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      try {
-        await unlink(path);
-        return;
-      } catch (error) {
-        if (error instanceof Error && 'code' in error && error.code === 'ENOENT') return;
-        if (attempt === 4) throw error;
-        await delay(25 * 2 ** attempt);
-      }
-    }
-  }));
-}
-
-async function materializeRemote(
-  reference: ExportMediaReference,
-  options: ResolvedServerExportMediaOptions,
-): Promise<{ localPath: string; publicPath: string } | ExportMediaIssue> {
-  let response: Response | undefined;
-  let partialPath: string | undefined;
-  let finalPath: string | undefined;
-  let handle: FileHandle | undefined;
-  let completed = false;
-  const timeoutSignal = AbortSignal.timeout(30 * 60_000);
-  const fetchSignal = options.signal
-    ? AbortSignal.any([options.signal, timeoutSignal])
-    : timeoutSignal;
-  try {
-    fetchSignal.throwIfAborted();
-    response = await options.fetcher(reference.source, {
-      method: 'GET',
-      cache: 'no-store',
-      signal: fetchSignal,
-    });
-    fetchSignal.throwIfAborted();
-    const contentType = response.headers.get('content-type');
-    if (isHtmlContentType(contentType)) {
-      return issueFor(
-        reference,
-        'missing_source',
-        `Media source resolved to HTML instead of media (HTTP ${response.status}): ${reference.source}`,
-      );
-    }
-    if (response.status !== 200 || !response.body) {
-      return issueFor(
-        reference,
-        response.status === 404 ? 'missing_source' : 'unreadable',
-        `Media source is not readable (HTTP ${response.status}): ${reference.source}`,
-      );
-    }
-    const declaredLength = Number(response.headers.get('content-length'));
-    if (Number.isFinite(declaredLength) && declaredLength > options.maxMaterializedBytes) {
-      return issueFor(reference, 'unreadable', `Media source exceeds the materialization limit: ${reference.source}`);
-    }
-
-    await mkdir(options.uploadDirectory, { recursive: true });
-    fetchSignal.throwIfAborted();
-    const filename = `openchatcut-render-media-${randomUUID()}${extensionFor(reference.source, contentType)}`;
-    finalPath = resolve(options.uploadDirectory, filename);
-    partialPath = `${finalPath}.part`;
-    handle = await open(partialPath, 'wx', 0o600);
-    fetchSignal.throwIfAborted();
-    const reader = response.body.getReader();
-    let bytes = 0;
-    try {
-      for (;;) {
-        fetchSignal.throwIfAborted();
-        const { done, value } = await reader.read();
-        fetchSignal.throwIfAborted();
-        if (done) break;
-        bytes += value.byteLength;
-        if (bytes > options.maxMaterializedBytes) {
-          throw new Error(`Media source exceeds the materialization limit: ${reference.source}`);
-        }
-        let offset = 0;
-        while (offset < value.byteLength) {
-          fetchSignal.throwIfAborted();
-          const { bytesWritten } = await handle.write(value.subarray(offset));
-          fetchSignal.throwIfAborted();
-          if (bytesWritten < 1) throw new Error(`Media source could not be written: ${reference.source}`);
-          offset += bytesWritten;
-        }
-      }
-    } catch (error) {
-      await reader.cancel(error).catch(() => undefined);
-      throw error;
-    }
-    if (bytes < 1) throw new Error(`Media source returned an empty body: ${reference.source}`);
-    await handle.sync();
-    fetchSignal.throwIfAborted();
-    await handle.close();
-    handle = undefined;
-    fetchSignal.throwIfAborted();
-    await rename(partialPath, finalPath);
-    partialPath = undefined;
-    fetchSignal.throwIfAborted();
-    completed = true;
-    return { localPath: finalPath, publicPath: `/media/uploads/${filename}` };
-  } catch (error) {
-    options.signal?.throwIfAborted();
-    return issueFor(
-      reference,
-      'unreadable',
-      `Media source could not be materialized: ${reference.source} (${error instanceof Error ? error.message : String(error)})`,
-    );
-  } finally {
-    await response?.body?.cancel().catch(() => undefined);
-    await handle?.close().catch(() => undefined);
-    if (partialPath) await unlink(partialPath).catch(() => undefined);
-    if (finalPath && !completed) await unlink(finalPath).catch(() => undefined);
-  }
-}
-
-async function checkLocalReference(
-  reference: ExportMediaReference,
-  options: ResolvedServerExportMediaOptions,
-): Promise<ExportMediaIssue | null> {
-  options.signal?.throwIfAborted();
-  if (reference.source.startsWith('data:')) return null;
-  if (reference.source.startsWith('blob:')) {
-    return issueFor(reference, 'unsupported_source', `Blob URL is not readable by the export server: ${reference.source}`);
-  }
-  if (reference.source.startsWith('file:') || isAbsolute(reference.source) && !reference.source.startsWith('/')) {
-    return issueFor(reference, 'unsupported_source', `Local file source is not mapped for export: ${reference.source}`);
-  }
-
-  const rawPathname = reference.source.split(/[?#]/, 1)[0] ?? '';
-  let pathname: string;
-  try {
-    pathname = decodeURIComponent(rawPathname);
-  } catch {
-    return issueFor(reference, 'unsupported_source', `Media source has invalid path encoding: ${reference.source}`);
-  }
-  const uploadPrefix = '/media/uploads/';
-  if (pathname.startsWith(uploadPrefix)) {
-    const name = pathname.slice(uploadPrefix.length);
-    if (!isSafeUploadName(name)) {
-      return issueFor(reference, 'unsupported_source', `Media upload name is unsafe: ${reference.source}`);
-    }
-    const local = options.resolveUpload(name);
-    if (local) {
-      const readable = await readableFile(local);
-      options.signal?.throwIfAborted();
-      return readable
-        ? null
-        : issueFor(reference, 'unreadable', `Media upload is not readable: ${reference.source}`);
-    }
-    let hydrated: ResolvedUploadFile | null;
-    try {
-      hydrated = await options.hydrateUpload(name, options.signal);
-      options.signal?.throwIfAborted();
-    } catch (error) {
-      options.signal?.throwIfAborted();
-      return issueFor(
-        reference,
-        'unreadable',
-        `Media upload could not be restored: ${reference.source} (${error instanceof Error ? error.message : String(error)})`,
-      );
-    }
-    if (!hydrated) return issueFor(reference, 'missing_source', `Media upload is missing: ${reference.source}`);
-    if (isHtmlContentType(hydrated.contentType)) {
-      return issueFor(reference, 'missing_source', `Media upload resolved to HTML instead of media: ${reference.source}`);
-    }
-    const readable = await readableFile(hydrated.file);
-    options.signal?.throwIfAborted();
-    return readable
-      ? null
-      : issueFor(reference, 'unreadable', `Restored media upload is not readable: ${reference.source}`);
-  }
-  if (!pathname.startsWith('/')) {
-    return issueFor(reference, 'unsupported_source', `Relative media source is not mapped for export: ${reference.source}`);
-  }
-  const candidate = resolve(options.publicDirectory, `.${pathname}`);
-  const escaped = relative(options.publicDirectory, candidate);
-  if (escaped === '..' || escaped.startsWith(`..${sep}`) || isAbsolute(escaped)) {
-    return issueFor(reference, 'unsupported_source', `Media source escapes the public directory: ${reference.source}`);
-  }
-  const readable = await readableFile(candidate);
-  options.signal?.throwIfAborted();
-  if (readable) return null;
-
-  // Product-bundled media is served at the same root-absolute URL paths as
-  // public media by productAssetsPlugin. Keep this lookup behind the same
-  // resolver so export preflight and the static renderer agree on disk layout.
-  const productAsset = resolveProductAsset(rawPathname);
-  const productReadable = productAsset ? await readableFile(productAsset) : false;
-  options.signal?.throwIfAborted();
-  return productReadable
-    ? null
-    : issueFor(reference, 'missing_source', `Public or product media source is missing or unreadable: ${reference.source}`);
-}
-
-
-function replaceMaterializedSources(value: unknown, replacements: ReadonlyMap<string, string>, seen: WeakSet<object>): void {
-  if (value === null || typeof value !== 'object' || seen.has(value)) return;
-  seen.add(value);
-  if (Array.isArray(value)) {
-    for (let index = 0; index < value.length; index += 1) {
-      const child = value[index];
-      if (typeof child === 'string') value[index] = replacements.get(child) ?? child;
-      else replaceMaterializedSources(child, replacements, seen);
-    }
-    return;
-  }
-  for (const [key, child] of Object.entries(value)) {
-    if (typeof child === 'string') {
-      if (replacements.has(child)) Reflect.set(value, key, replacements.get(child));
-    } else {
-      replaceMaterializedSources(child, replacements, seen);
-    }
-  }
-}
-
-function freezeSnapshot(value: unknown, seen: WeakSet<object>): void {
-  if (value === null || typeof value !== 'object' || seen.has(value)) return;
-  seen.add(value);
-  for (const child of Object.values(value)) freezeSnapshot(child, seen);
-  Object.freeze(value);
-}
-
-function resolvedOptions(options: ServerExportMediaOptions): ResolvedServerExportMediaOptions {
-  const requestedLimit = options.maxMaterializedBytes;
-  const maxMaterializedBytes = typeof requestedLimit === 'number'
-    && Number.isFinite(requestedLimit)
-    && requestedLimit > 0
-    ? Math.floor(requestedLimit)
-    : MAX_MATERIALIZED_MEDIA_BYTES;
-  return {
-    publicDirectory: resolve(options.publicDirectory ?? resolve(process.cwd(), 'public')),
-    uploadDirectory: resolve(options.uploadDirectory ?? uploadDir()),
-    fetcher: options.fetcher ?? safePublicFetch,
-    resolveUpload: options.resolveUpload ?? resolveUploadFile,
-    hydrateUpload: options.hydrateUpload
-      ?? ((name, signal) => resolveOrHydrateUploadFile(name, undefined, signal)),
-    maxMaterializedBytes,
-    signal: options.signal,
-  };
-}
-
-function preflightFailure(issues: readonly ExportMediaIssue[]): ExportFailureError {
-  const detail = issues.map((issue) => `${issue.code}: ${issue.source}${issue.message ? ` (${issue.message})` : ''}`).join('; ');
-  return new ExportFailureError(createExportFailure({
-    stage: 'preflight',
-    code: 'export_media_preflight_failed',
-    retryable: false,
-    message: `Export media preflight failed for ${issues.length} reference${issues.length === 1 ? '' : 's'}: ${detail}`,
-    mediaIssues: [...issues],
-  }));
-}
-
-/**
- * Resolve every render-visible external URL exactly once through safePublicFetch,
- * atomically publish it under the controlled upload directory, and freeze a
- * snapshot whose renderer-visible references are same-origin paths.
- */
-export async function materializeServerExportMedia<Value>(
-  snapshot: Value,
-  options: ServerExportMediaOptions = {},
-): Promise<MaterializedServerExportMedia<Value>> {
-  options.signal?.throwIfAborted();
-  const plan = collectExportMediaPlan(snapshot);
-  options.signal?.throwIfAborted();
-  if (plan.issues.length > 0) throw preflightFailure(plan.issues);
-  const resolved = resolvedOptions(options);
-  const remoteReferences = plan.references.filter((reference) => /^https?:\/\//i.test(reference.source));
-  const localReferences = plan.references.filter((reference) => !/^https?:\/\//i.test(reference.source));
-  const replacements = new Map<string, string>();
-  const localPaths: string[] = [];
-  try {
-    const localIssues = (await Promise.all(
-      localReferences.map((reference) => checkLocalReference(reference, resolved)),
-    )).filter((issue): issue is ExportMediaIssue => issue !== null);
-    resolved.signal?.throwIfAborted();
-    if (localIssues.length > 0) throw preflightFailure(localIssues);
-
-    const remoteIssues: ExportMediaIssue[] = [];
-    const attemptedRemoteSources = new Set<string>();
-    for (const reference of remoteReferences) {
-      resolved.signal?.throwIfAborted();
-      if (attemptedRemoteSources.has(reference.source)) continue;
-      attemptedRemoteSources.add(reference.source);
-      const materialized = await materializeRemote(reference, resolved);
-      if ('code' in materialized) {
-        resolved.signal?.throwIfAborted();
-        remoteIssues.push(materialized);
-        continue;
-      }
-      replacements.set(reference.source, materialized.publicPath);
-      localPaths.push(materialized.localPath);
-      resolved.signal?.throwIfAborted();
-    }
-    if (remoteIssues.length > 0) throw preflightFailure(remoteIssues);
-
-    resolved.signal?.throwIfAborted();
-    const immutable = structuredClone(snapshot);
-    replaceMaterializedSources(immutable, replacements, new WeakSet());
-    freezeSnapshot(immutable, new WeakSet());
-    resolved.signal?.throwIfAborted();
-    let cleanupPromise: Promise<void> | undefined;
-    return Object.freeze({
-      snapshot: immutable,
-      plan,
-      localPaths: Object.freeze([...localPaths]),
-      cleanup: () => cleanupPromise ??= cleanupPaths(localPaths),
-    });
-  } catch (error) {
-    await cleanupPaths(localPaths);
-    throw error;
-  }
-}
-
-export async function validateServerExportMedia(
-  snapshot: unknown,
-  options: ServerExportMediaOptions = {},
-): Promise<ExportMediaPlan> {
-  const materialized = await materializeServerExportMedia(snapshot, options);
-  await materialized.cleanup();
-  return materialized.plan;
 }

--- a/server/plugins/export-media-plan.ts
+++ b/server/plugins/export-media-plan.ts
@@ -20,6 +20,7 @@ import {
   uploadDir,
   type ResolvedUploadFile,
 } from '../media-dir.ts';
+import { resolveProductAsset } from '../product-assets.ts';
 import { safePublicFetch } from '../safe-public-fetch.ts';
 
 const MAX_MATERIALIZED_MEDIA_BYTES = 10 * 1024 * 1024 * 1024;
@@ -228,9 +229,10 @@ async function checkLocalReference(
     return issueFor(reference, 'unsupported_source', `Local file source is not mapped for export: ${reference.source}`);
   }
 
+  const rawPathname = reference.source.split(/[?#]/, 1)[0] ?? '';
   let pathname: string;
   try {
-    pathname = decodeURIComponent(reference.source.split(/[?#]/, 1)[0] ?? '');
+    pathname = decodeURIComponent(rawPathname);
   } catch {
     return issueFor(reference, 'unsupported_source', `Media source has invalid path encoding: ${reference.source}`);
   }
@@ -280,9 +282,17 @@ async function checkLocalReference(
   }
   const readable = await readableFile(candidate);
   options.signal?.throwIfAborted();
-  return readable
+  if (readable) return null;
+
+  // Product-bundled media is served at the same root-absolute URL paths as
+  // public media by productAssetsPlugin. Keep this lookup behind the same
+  // resolver so export preflight and the static renderer agree on disk layout.
+  const productAsset = resolveProductAsset(rawPathname);
+  const productReadable = productAsset ? await readableFile(productAsset) : false;
+  options.signal?.throwIfAborted();
+  return productReadable
     ? null
-    : issueFor(reference, 'missing_source', `Public media source is missing or unreadable: ${reference.source}`);
+    : issueFor(reference, 'missing_source', `Public or product media source is missing or unreadable: ${reference.source}`);
 }
 
 

--- a/server/plugins/export-product-assets.verify.ts
+++ b/server/plugins/export-product-assets.verify.ts
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import { resolveProductAsset } from '../product-assets.ts';
+import { validateServerExportMedia } from './export-media-plan.ts';
+
+const source = '/audio/track-2.mp3';
+const itemId = 'product-audio';
+
+assert.ok(resolveProductAsset(source), 'the bundled product audio fixture must exist');
+
+const plan = await validateServerExportMedia({
+  items: [{ id: itemId, kind: 'audio', src: `${source}?cache=1` }],
+});
+
+assert.equal(plan.issues.length, 0, 'bundled product media must pass server export preflight');
+console.log('server product asset export preflight verification passed');


### PR DESCRIPTION
## 变更

让导出预检识别已经随项目打包的产品素材，并补充对应的回归验证。

## 原因

产品素材可能不在时间线素材列表中，但导出计划仍然需要把它们作为有效的项目资源处理；原有预检会因此误报素材缺失。

## 验证

- npx tsx server/plugins/export-product-assets.verify.ts
- 针对修改文件执行 oxlint
- git diff --check

改动范围只涉及导出预检和测试，作为 Draft PR 提交。