### PR TITLE
test(windows): normalize media verification paths

### DIFF
--- a/server/plugins/normalize-media.verify.ts
+++ b/server/plugins/normalize-media.verify.ts
@@ -51,11 +51,13 @@ assert.equal(
   'the published target always uses the normalized .mp4 extension',
 );
 
+const canonicalTestPath = (path: string): string => path.replaceAll('\\', '/');
 const missingTargetRealpath = async (path: string): Promise<string> => {
-  if (path.startsWith('/alias/')) {
+  const canonicalPath = canonicalTestPath(path);
+  if (canonicalPath.startsWith('/alias/')) {
     throw Object.assign(new Error(`missing: ${path}`), { code: 'ENOENT' });
   }
-  assert.equal(path, '/alias');
+  assert.equal(canonicalPath, '/alias');
   return '/Volumes/Me\u0301dia';
 };
 assert.equal(
@@ -79,7 +81,7 @@ assert.notEqual(linuxNfcKey, linuxNfdKey, 'Linux preserves normalization-distinc
 let existingTargetRealpathCalls = 0;
 const existingTargetKey = await resolveNormalizeTargetKey('/alias/Clip.mp4', 'darwin', async (path) => {
   existingTargetRealpathCalls += 1;
-  assert.equal(path, '/alias/Clip.mp4');
+  assert.equal(canonicalTestPath(path), '/alias/Clip.mp4');
   return '/Actual/Caf\u00e9.mp4';
 });
 assert.equal(existingTargetKey, '/actual/caf\u00e9.mp4');


### PR DESCRIPTION
## 变更

让媒体验证测试统一规范路径表示，兼容 Windows 路径分隔符。

## 原因

Windows 使用反斜杠路径时，验证逻辑会把同一个媒体路径误判为不同路径，导致测试失败；生产代码行为不变。

## 验证

- npx tsx server/plugins/normalize-media.verify.ts
- 针对修改文件执行 oxlint
- git diff --check

这是一个范围明确的跨平台测试修复，作为 Draft PR 提交。