### PR TITLE
fix: refresh editor leases during long polls

### DIFF
--- a/server/external-agent/broker-poll-refresh.verify.ts
+++ b/server/external-agent/broker-poll-refresh.verify.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { mock } from 'node:test';
+import {
+  isProjectConnected,
+  nextEditorCall,
+  registerEditor,
+  resetExternalAgentBrokerForTest,
+} from './broker.ts';
+
+const projectId = 'project-poll-refresh';
+const editorId = 'editor-poll-refresh';
+const revision = 'v1-poll-refresh';
+const tools = [{
+  name: 'read_timeline',
+  input_schema: { type: 'object' as const, properties: {} },
+}];
+
+resetExternalAgentBrokerForTest();
+mock.timers.enable({ apis: ['Date', 'setTimeout'] });
+try {
+  const registrationCapability = registerEditor(projectId, editorId, revision, tools, undefined, null);
+  const poll = nextEditorCall(
+    projectId,
+    editorId,
+    revision,
+    new AbortController().signal,
+    registrationCapability,
+  );
+
+  // Let each refresh segment run before advancing to the next one. The final
+  // 40-second observation distinguishes the refreshed lease from the old
+  // single 25-second wait, which would leave lastSeen at time zero.
+  await Promise.resolve();
+  mock.timers.tick(8_000);
+  await Promise.resolve();
+  mock.timers.tick(8_000);
+  await Promise.resolve();
+  mock.timers.tick(8_000);
+  await Promise.resolve();
+  mock.timers.tick(1_000);
+  assert.equal(await poll, null, 'an idle long-poll ends after its budget');
+  mock.timers.setTime(40_000);
+  assert.equal(
+    isProjectConnected(projectId),
+    true,
+    'a long-poll refreshes lastSeen before the editor online lease expires',
+  );
+} finally {
+  mock.timers.reset();
+  resetExternalAgentBrokerForTest();
+}
+
+console.log('broker-poll-refresh.verify: ok');

--- a/server/external-agent/broker.ts
+++ b/server/external-agent/broker.ts
@@ -50,6 +50,10 @@ export interface ExternalEditorCancellation {
   message: string;
 }
 
+/** Total time a single editor long-poll waits for an incoming call. */
+const EDITOR_POLL_BUDGET_MS = 25_000;
+/** Refresh the editor registration before the online lease can expire. */
+const EDITOR_POLL_REFRESH_MS = 8_000;
 const DEFAULT_TIMEOUT_MS = 180_000;
 const MAX_TIMEOUT_MS = 600_000;
 const queues = new Map<string, QueuedCall[]>();
@@ -412,15 +416,29 @@ export async function nextEditorCall(
   let binding = editorBinding(projectId);
   let call = binding ? takeNextCall(projectId, binding) : undefined;
   if (!call) {
-    await waitForWake(waiters, projectId, signal, 25_000);
-    if (signal.aborted || !(await touchEditor(
-      projectId,
-      editorInstanceId,
-      baseRevision,
-      registrationCapability,
-    ))) return null;
-    binding = editorBinding(projectId);
-    call = binding ? takeNextCall(projectId, binding) : undefined;
+    // Keep the long-poll responsive while refreshing lastSeen. A single
+    // 25-second wait can let an actively-polling editor approach its online
+    // lease boundary on a slow link and appear offline during a read.
+    const startedAt = Date.now();
+    while (!signal.aborted) {
+      const remaining = EDITOR_POLL_BUDGET_MS - (Date.now() - startedAt);
+      if (remaining <= 0) break;
+      await waitForWake(
+        waiters,
+        projectId,
+        signal,
+        Math.min(EDITOR_POLL_REFRESH_MS, remaining),
+      );
+      if (signal.aborted || !(await touchEditor(
+        projectId,
+        editorInstanceId,
+        baseRevision,
+        registrationCapability,
+      ))) return null;
+      binding = editorBinding(projectId);
+      call = binding ? takeNextCall(projectId, binding) : undefined;
+      if (call) break;
+    }
   }
   if (!call) return null;
   return {

--- a/server/external-agent/broker.verify.ts
+++ b/server/external-agent/broker.verify.ts
@@ -109,4 +109,5 @@ assert.throws(
 );
 
 await import('./mcp.verify.ts');
+await import('./broker-poll-refresh.verify.ts');
 console.log('external-agent broker check passed');


### PR DESCRIPTION
## 变更

把编辑器长轮询拆成定时续活的等待片段，在等待期间刷新编辑器租约，并新增定时器回归测试。

## 原因

长轮询没有活动调用时，编辑器租约可能在响应返回前过期，导致项目连接状态错误地变为离线。

## 验证

- npx tsx server/external-agent/broker-poll-refresh.verify.ts
- npx tsx server/external-agent/broker.verify.ts
- 针对修改文件执行 oxlint
- git diff --check

提交内容来自干净的 origin/main，作为独立 Draft PR。