### PR TITLE
feat(agent): place images on music beats

### DIFF
--- a/assets/agent/openchatcut-tool-schemas.json
+++ b/assets/agent/openchatcut-tool-schemas.json
@@ -5001,6 +5001,129 @@
       }
     },
     {
+      "name": "music_image_plan",
+      "description": "Build a deterministic, read-only photo placement plan from cached music analysis and the BGM clip trim/speed mapping. The plan fills the requested range with media-pool images, changing images at beat/downbeat/section boundaries and cycling the selected image order. Call this before sync_images_to_music so the user can review the bounded placement plan. This tool never starts analysis.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "description": "BGM timeline audio/video clip id (unique prefix accepted)."
+          },
+          "timing": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "beat",
+              "downbeat",
+              "section"
+            ],
+            "description": "Photo-change timing. auto chooses section/downbeat/beat deterministically from density and available analysis."
+          },
+          "density": {
+            "type": "string",
+            "enum": [
+              "sparse",
+              "medium",
+              "dense"
+            ],
+            "description": "How many analyzed timing points to retain."
+          },
+          "fromFrame": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Optional inclusive timeline-frame range start; defaults to the BGM clip start."
+          },
+          "toFrame": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Optional exclusive timeline-frame range end; defaults to the BGM clip end."
+          },
+          "imageAssetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 64,
+            "description": "Optional image asset ids/prefixes in display order. Defaults to all image assets in media-pool order and cycles when needed."
+          },
+          "track": {
+            "type": "string",
+            "description": "Optional target video track id or alias, default V1. The target range must be empty and unlocked."
+          }
+        },
+        "required": [
+          "itemId",
+          "timing",
+          "density"
+        ]
+      }
+    },
+    {
+      "name": "sync_images_to_music",
+      "description": "Recompute a cached music image plan and add one image clip per planned beat interval. Pass the analysisRef returned by music_image_plan to reject stale analysis. All image additions are one EditorCommands batch and one undo step. The target video track must be unlocked and empty in the requested range; this never starts analysis and never edits the BGM clip.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "description": "BGM timeline audio/video clip id (unique prefix accepted)."
+          },
+          "timing": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "beat",
+              "downbeat",
+              "section"
+            ],
+            "description": "Photo-change timing. auto chooses section/downbeat/beat deterministically from density and available analysis."
+          },
+          "density": {
+            "type": "string",
+            "enum": [
+              "sparse",
+              "medium",
+              "dense"
+            ],
+            "description": "How many analyzed timing points to retain."
+          },
+          "fromFrame": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Optional inclusive timeline-frame range start; defaults to the BGM clip start."
+          },
+          "toFrame": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Optional exclusive timeline-frame range end; defaults to the BGM clip end."
+          },
+          "imageAssetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 64,
+            "description": "Optional image asset ids/prefixes in display order. Defaults to all image assets in media-pool order and cycles when needed."
+          },
+          "track": {
+            "type": "string",
+            "description": "Optional target video track id or alias, default V1. The target range must be empty and unlocked."
+          },
+          "analysisRef": {
+            "type": "string",
+            "description": "Opaque ref from music_image_plan. Execution rejects missing or stale analysis."
+          }
+        },
+        "required": [
+          "itemId",
+          "timing",
+          "density",
+          "analysisRef"
+        ]
+      }
+    },
+    {
       "name": "review_scene_plan",
       "description": "Advisory review of a multi-scene plan for repetition, decorative visuals, static-card overuse, and generic language. Returns a normalized 0–5 risk score, revision advice, and affected scene numbers. The report is optional advice and never blocks or authorizes submit_image/submit_video.",
       "input_schema": {
@@ -5677,6 +5800,65 @@
             },
             "maxItems": 64,
             "description": "Optional video clip ids/prefixes to constrain targets. Defaults to video clips overlapping the range."
+          }
+        },
+        "required": [
+          "itemId",
+          "timing",
+          "density"
+        ]
+      }
+    },
+    {
+      "name": "music_image_plan",
+      "description": "Build a deterministic, read-only photo placement plan from cached music analysis and the BGM clip trim/speed mapping. The plan fills the requested range with media-pool images, changing images at beat/downbeat/section boundaries and cycling the selected image order. Call this before sync_images_to_music so the user can review the bounded placement plan. This tool never starts analysis.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "description": "BGM timeline audio/video clip id (unique prefix accepted)."
+          },
+          "timing": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "beat",
+              "downbeat",
+              "section"
+            ],
+            "description": "Photo-change timing. auto chooses section/downbeat/beat deterministically from density and available analysis."
+          },
+          "density": {
+            "type": "string",
+            "enum": [
+              "sparse",
+              "medium",
+              "dense"
+            ],
+            "description": "How many analyzed timing points to retain."
+          },
+          "fromFrame": {
+            "type": "number",
+            "minimum": 0,
+            "description": "Optional inclusive timeline-frame range start; defaults to the BGM clip start."
+          },
+          "toFrame": {
+            "type": "number",
+            "minimum": 1,
+            "description": "Optional exclusive timeline-frame range end; defaults to the BGM clip end."
+          },
+          "imageAssetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 64,
+            "description": "Optional image asset ids/prefixes in display order. Defaults to all image assets in media-pool order and cycles when needed."
+          },
+          "track": {
+            "type": "string",
+            "description": "Optional target video track id or alias, default V1. The target range must be empty and unlocked."
           }
         },
         "required": [

--- a/src/agent/execution-policy.ts
+++ b/src/agent/execution-policy.ts
@@ -21,7 +21,7 @@ export type ToolInvocationValidation =
 
 const READ_TOOLS = new Set([
   'read_agent_artifact', 'ToolSearch', 'track_progress', 'track_export',
-  'inspect_color', 'analyze_music', 'inspect_music', 'music_edit_plan', 'probe_media',
+  'inspect_color', 'analyze_music', 'inspect_music', 'music_edit_plan', 'music_image_plan', 'probe_media',
   'analyze_scene_quality', 'report_user_friction', 'get_editor_url',
 ]);
 const PERSISTENT_LOCAL_TOOLS = new Set([

--- a/src/agent/external-tool-policy.ts
+++ b/src/agent/external-tool-policy.ts
@@ -7,7 +7,7 @@ const READ_ONLY_TOOL_NAMES = new Set([
   'read_timeline', 'list_templates', 'search_templates', 'list_audio',
   'read_script', 'view_timeline_frames', 'view_asset_frames', 'browse_library',
   'read_captions', 'read_project', 'read_transcript', 'find_transcript',
-  'search_media', 'search_stock_media', 'search_fonts', 'analyze_music', 'inspect_music', 'music_edit_plan',
+  'search_media', 'search_stock_media', 'search_fonts', 'analyze_music', 'inspect_music', 'music_edit_plan', 'music_image_plan',
   'read_agent_artifact',
 ]);
 
@@ -17,7 +17,7 @@ const DRAFT_EDIT_TOOL_NAMES = new Set([
   'set_aspect_ratio', 'manage_timelines', 'edit_track', 'apply_script',
   'edit_item', 'manage_effects', 'edit_captions', 'update_watermark',
   'manage_markers', 'apply_caption_avoidance', 'place_graphics_in_safe_zone', 'auto_reframe',
-  'manage_design_style',
+  'manage_design_style', 'sync_images_to_music',
 ]);
 
 const SERVER_DIRECT_READ_TOOL_NAMES: Record<string, true> = {

--- a/src/agent/skills/music-intelligence/SKILL.md
+++ b/src/agent/skills/music-intelligence/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: music-intelligence
 description: |
-  Run or inspect local music analysis and plan or apply beat-, downbeat-, or section-synced video cuts.
+  Run or inspect local music analysis and plan or apply beat-, downbeat-, or section-synced video cuts or photo placements.
   Use for BGM beat edits, rhythm cuts, 卡点剪辑, musical structure, BPM, mood, genre, or instrument questions.
 user-invocable: false
 ---
@@ -10,8 +10,8 @@ user-invocable: false
 
 1. Call `analyze_music` when the user asks to analyze music or no cache exists. It runs the installed local Beat This + CLAP models, waits for completion, and never downloads models; use `force:true` only for an explicit reanalysis request.
 2. Call `inspect_music` when only the existing cache is needed.
-3. Before editing, call `music_edit_plan` and show its bounded cut/target summary. Prefer `timing:auto`; choose sparse, medium, or dense from the requested pace.
-4. Only after the plan is accepted, call `sync_cuts_to_music` with the returned `analysisRef`. It recomputes the plan, rejects stale analysis, skips locked video tracks, and applies all splits as one undo step.
+3. Before cutting video, call `music_edit_plan` and show its bounded cut/target summary. Before placing photos, call `music_image_plan` and show its bounded placement summary. Prefer `timing:auto`; choose sparse, medium, or dense from the requested pace.
+4. Only after the plan is accepted, call `sync_cuts_to_music` or `sync_images_to_music` with the returned `analysisRef`. Each tool recomputes the plan, rejects stale analysis, and applies its changes as one undo step.
 5. If required model packs are missing, report the returned install guidance, then retry `analyze_music` after installation.
 6. Never request, return, quote, summarize, or place the CLAP embedding in model context. Use tags, sections, confidence, and the opaque `analysisRef` only.
 
@@ -34,9 +34,16 @@ user-invocable: false
 - Plans are bounded to 96 cut frames and 64 overlapping video targets. Report the returned summary and any cap or locked-target warning before applying.
 - A plan targets video clips that overlap the selected BGM range. It must never include or mutate the BGM item itself.
 
+## Photo placement
+
+- `music_image_plan` uses explicitly listed image asset ids in their given order, or all image assets in media-pool order when omitted. It cycles that order when the music range has more beat intervals than images.
+- Each placement covers the complete interval from one selected timing point to the next, including the BGM range boundaries, so images are not appended with their source duration or placed at a uniform default length.
+- Image placement is bounded to 96 clips and 64 image assets. `sync_images_to_music` requires an unlocked, empty target video track for the requested range; choose another track instead of overwriting existing content.
+
 ## Apply and recover
 
 - Pass the same `itemId`, timing, density, range, target ids, and `analysisRef` to `sync_cuts_to_music`. Execution recomputes the plan from current state; do not replay an old list of frames.
-- A missing or stale ref means the project or analysis changed. Call `inspect_music`, then `music_edit_plan`, and ask for acceptance again.
+- A missing or stale ref means the project or analysis changed. Call `inspect_music`, then `music_edit_plan` or `music_image_plan`, and ask for acceptance again.
 - Locked video tracks are skipped and reported. Never unlock a track implicitly.
 - Successful splits are submitted as one `EditorCommands.batch`, so the whole rhythm edit is one undo step.
+- Successful photo placements are submitted as one `EditorCommands.batch`, so the whole sequence is one undo step.

--- a/src/agent/tool-routing.ts
+++ b/src/agent/tool-routing.ts
@@ -80,6 +80,7 @@ const ROUTING_GROUPS: readonly RoutingGroup[] = [
     tools: [
       'list_audio', 'add_audio', 'normalize_loudness', 'isolate_voice', 'detect_beats',
       'analyze_music', 'inspect_music', 'music_edit_plan', 'sync_cuts_to_music',
+      'music_image_plan', 'sync_images_to_music',
     ],
   },
   {
@@ -131,6 +132,7 @@ const ROUTING_GROUPS: readonly RoutingGroup[] = [
     tools: [
       'view_timeline_frames', 'view_asset_frames', 'detect_scenes', 'find_highlights', 'auto_reframe',
       'multicam_sync', 'change_cam', 'inspect_color', 'auto_grade', 'detect_beats', 'inspect_music',
+      'music_image_plan', 'sync_images_to_music',
       'review_scene_plan',
     ],
   },

--- a/src/agent/tools/music-intelligence-tools.ts
+++ b/src/agent/tools/music-intelligence-tools.ts
@@ -5,7 +5,13 @@ export {
 
 import type { AgentContext } from '../context';
 import type { AtomicAction } from '../../editor/reduce';
-import type { MediaAsset, TimelineItem, TimelineState } from '../../editor/types';
+import {
+  defaultTrackId,
+  resolveTrackId,
+  type MediaAsset,
+  type TimelineItem,
+  type TimelineState,
+} from '../../editor/types';
 import {
   sourceFramesToTimelineFrames,
   sourceWindowForTimelineRange,
@@ -24,6 +30,8 @@ const MAX_INSPECT_SECTIONS = 16;
 const MAX_INSPECT_TAGS = 12;
 export const MAX_MUSIC_PLAN_CUTS = 96;
 export const MAX_MUSIC_PLAN_TARGETS = 64;
+export const MAX_MUSIC_IMAGE_PLACEMENTS = 96;
+const MAX_MUSIC_IMAGE_ASSETS = 64;
 
 const DENSITY_STRIDE: Record<MusicPlanDensity, number> = {
   sparse: 4,
@@ -43,6 +51,28 @@ export interface MusicPlanOptions {
   readonly targetItemIds?: readonly string[];
 }
 
+export interface MusicImagePlanOptions extends MusicPlanOptions {
+  readonly imageAssetIds?: readonly string[];
+  readonly track?: string;
+}
+
+export interface MusicImagePlacement {
+  readonly assetId: string;
+  readonly startFrame: number;
+  readonly durationInFrames: number;
+}
+
+export interface MusicImageEditPlan {
+  readonly schemaVersion: 1;
+  readonly analysisRef: string;
+  readonly musicItemId: string;
+  readonly imageAssetIds: string[];
+  readonly track: string;
+  readonly timing: MusicEditPlan['timing'];
+  readonly range: MusicEditPlan['range'];
+  readonly placements: MusicImagePlacement[];
+}
+
 interface ResolvedMusicTarget {
   readonly asset: MediaAsset;
   readonly item?: TimelineItem;
@@ -54,6 +84,12 @@ interface BuiltPlan {
   readonly overlappingTargetCount: number;
   readonly lockedTargetCount: number;
   readonly targetLimitReached: boolean;
+}
+
+interface BuiltImagePlan {
+  readonly plan: MusicImageEditPlan;
+  readonly availableCutCount: number;
+  readonly imageCount: number;
 }
 
 function resolvePrefix<T extends { readonly id: string }>(
@@ -132,7 +168,7 @@ async function unavailableAnalysis(asset: MediaAsset): Promise<Record<string, un
     // Catalog status is advisory here; cache absence remains the authoritative result.
   }
   return {
-    error: 'music has not been analyzed yet; analyze this asset from the media pool, then retry',
+    error: 'music has not been analyzed yet; call analyze_music for this asset, then retry',
     assetId: asset.id,
     requiredModelPacks: required,
   };
@@ -260,6 +296,14 @@ function normalizePlanOptions(args: Args): MusicPlanOptions {
   };
 }
 
+function normalizeImagePlanOptions(args: Args): MusicImagePlanOptions {
+  const imageAssetIds = Array.isArray(args.imageAssetIds)
+    ? args.imageAssetIds.filter((value): value is string => typeof value === 'string' && value.trim() !== '')
+    : undefined;
+  const track = typeof args.track === 'string' && args.track.trim() ? args.track.trim() : undefined;
+  return { ...normalizePlanOptions(args), imageAssetIds, track };
+}
+
 function planRange(item: TimelineItem, options: MusicPlanOptions): MusicEditPlan['range'] {
   const itemEnd = item.startFrame + item.durationInFrames;
   const fromFrame = Math.max(item.startFrame, Math.round(options.fromFrame ?? item.startFrame));
@@ -353,13 +397,128 @@ export function buildMusicEditPlan(
     targetLimitReached: allTargets.length > targets.length,
   };
 }
+
+function selectedImageAssets(
+  assets: readonly MediaAsset[],
+  options: MusicImagePlanOptions,
+): MediaAsset[] {
+  const images = assets.filter((asset) => asset.kind === 'image');
+  const selected = options.imageAssetIds?.length
+    ? options.imageAssetIds.map((id) => resolvePrefix(images, id.trim(), 'image asset'))
+    : images;
+  return [...new Map(selected.map((asset) => [asset.id, asset])).values()]
+    .slice(0, MAX_MUSIC_IMAGE_ASSETS);
+}
+
+function imageTrack(state: TimelineState, requested?: string): string {
+  if (requested !== undefined) {
+    const track = resolveTrackId(state, requested, 'video');
+    if (!track) throw new Error(`video track "${requested}" not found; call edit_track action=list`);
+    return track;
+  }
+  const track = resolveTrackId(state, 'V1', 'video') ?? defaultTrackId(state, 'video');
+  if (!track) throw new Error('no video track for photo placement — create one with edit_track first');
+  return track;
+}
+
+export function buildMusicImagePlacementPlan(
+  analysis: MusicAnalysis,
+  analysisRef: string,
+  musicItem: TimelineItem,
+  state: TimelineState,
+  assets: readonly MediaAsset[],
+  options: MusicImagePlanOptions,
+): BuiltImagePlan {
+  const range = planRange(musicItem, options);
+  const images = selectedImageAssets(assets, options);
+  if (!images.length) throw new Error('no image assets available for photo placement');
+  const timing = chooseTiming(analysis, musicItem, state, options, range);
+  const mapped = mapSourcePoints(timingPoints(analysis, timing), musicItem, state.fps)
+    .filter((frame) => frame > range.fromFrame && frame < range.toFrame);
+  const sampled = mapped.filter((_, index) => index % DENSITY_STRIDE[options.density] === 0);
+  const cutFrames = [...new Set(sampled)].slice(0, Math.max(0, MAX_MUSIC_IMAGE_PLACEMENTS - 1));
+  const boundaries = [range.fromFrame, ...cutFrames, range.toFrame];
+  const placements: MusicImagePlacement[] = [];
+  for (let index = 0; index < boundaries.length - 1; index += 1) {
+    const startFrame = boundaries[index]!;
+    const endFrame = boundaries[index + 1]!;
+    if (endFrame <= startFrame) continue;
+    placements.push({
+      assetId: images[index % images.length]!.id,
+      startFrame,
+      durationInFrames: endFrame - startFrame,
+    });
+  }
+  return {
+    plan: {
+      schemaVersion: 1,
+      analysisRef,
+      musicItemId: musicItem.id,
+      imageAssetIds: images.map((asset) => asset.id),
+      track: imageTrack(state, options.track),
+      timing,
+      range,
+      placements,
+    },
+    availableCutCount: sampled.length,
+    imageCount: images.length,
+  };
+}
+
+interface ImagePlacementActions {
+  readonly actions: AtomicAction[];
+  readonly trackLocked: boolean;
+  readonly conflictingItemIds: string[];
+  readonly missingAssetIds: string[];
+}
+
+export function buildMusicImagePlacementActions(
+  plan: MusicImageEditPlan,
+  state: TimelineState,
+  assets: readonly MediaAsset[],
+): ImagePlacementActions {
+  const assetById = new Map(assets.filter((asset) => asset.kind === 'image').map((asset) => [asset.id, asset]));
+  const missingAssetIds = [...new Set(plan.placements
+    .map((placement) => placement.assetId)
+    .filter((assetId) => !assetById.has(assetId)))];
+  const conflictingItemIds = [...new Set(state.items
+    .filter((item) => item.track === plan.track && item.startFrame < plan.range.toFrame
+      && item.startFrame + item.durationInFrames > plan.range.fromFrame)
+    .map((item) => item.id))];
+  const trackLocked = state.tracks?.[plan.track]?.locked === true;
+  if (trackLocked || conflictingItemIds.length || missingAssetIds.length) {
+    return { actions: [], trackLocked, conflictingItemIds, missingAssetIds };
+  }
+  const actions: AtomicAction[] = plan.placements.flatMap((placement) => {
+    const asset = assetById.get(placement.assetId);
+    if (!asset) return [];
+    const item: Omit<TimelineItem, 'startFrame'> = {
+      id: `item_${crypto.randomUUID()}`,
+      track: plan.track,
+      durationInFrames: placement.durationInFrames,
+      kind: 'image',
+      name: asset.name,
+      src: asset.src,
+      sourceAssetId: asset.id,
+      sourceFilename: asset.sourceFilename,
+      originalFilePath: asset.originalFilePath,
+      sourceRevision: asset.sourceRevision,
+      sourceContentHash: asset.sourceContentHash,
+      width: asset.width,
+      height: asset.height,
+    };
+    return [{ type: 'add', item, startFrame: placement.startFrame } satisfies AtomicAction];
+  });
+  return { actions, trackLocked, conflictingItemIds, missingAssetIds };
+}
 export function staleMusicAnalysisResult(
   supplied: unknown,
   current: string,
+  planToolName = 'music_edit_plan',
 ): Record<string, unknown> | null {
   if (typeof supplied !== 'string' || supplied === current) return null;
   return {
-    error: 'stale music analysisRef; call music_edit_plan again before editing',
+    error: `stale music analysisRef; call ${planToolName} again before editing`,
     staleAnalysisRef: true,
     currentAnalysisRef: current,
   };
@@ -383,6 +542,31 @@ async function currentPlan(
   return buildMusicEditPlan(analysis, ref, target.item, ctx.getState(), normalizePlanOptions(args));
 }
 
+async function currentImagePlan(
+  args: Args,
+  ctx: AgentContext,
+  requireAnalysisRef = false,
+): Promise<BuiltImagePlan | Record<string, unknown>> {
+  const target = resolveMusicTarget({ itemId: args.itemId }, ctx);
+  if (!target.item) throw new Error('itemId is required for a music image plan');
+  const analysis = await loadMusicAnalysisForAsset(target.asset);
+  if (!analysis) return await unavailableAnalysis(target.asset);
+  const ref = musicAnalysisRef(analysis);
+  if (requireAnalysisRef && typeof args.analysisRef !== 'string') {
+    return { error: 'analysisRef is required; call music_image_plan before editing', missingAnalysisRef: true };
+  }
+  const stale = staleMusicAnalysisResult(args.analysisRef, ref, 'music_image_plan');
+  if (stale) return stale;
+  return buildMusicImagePlacementPlan(
+    analysis,
+    ref,
+    target.item,
+    ctx.getState(),
+    ctx.getDoc().assets,
+    normalizeImagePlanOptions(args),
+  );
+}
+
 function planResponse(built: BuiltPlan): Record<string, unknown> {
   return {
     ...built.plan,
@@ -400,6 +584,23 @@ function planResponse(built: BuiltPlan): Record<string, unknown> {
 
 function isBuiltPlan(value: BuiltPlan | Record<string, unknown>): value is BuiltPlan {
   return 'plan' in value;
+}
+
+function isBuiltImagePlan(value: BuiltImagePlan | Record<string, unknown>): value is BuiltImagePlan {
+  return 'plan' in value;
+}
+
+function imagePlanResponse(built: BuiltImagePlan): Record<string, unknown> {
+  return {
+    ...built.plan,
+    summary: {
+      placements: built.plan.placements.length,
+      images: built.imageCount,
+      availableCuts: built.availableCutCount,
+      timing: built.plan.timing,
+      capped: built.availableCutCount > Math.max(0, MAX_MUSIC_IMAGE_PLACEMENTS - 1),
+    },
+  };
 }
 
 export function buildMusicSplitActions(
@@ -455,6 +656,55 @@ async function syncCuts(args: Args, ctx: AgentContext): Promise<unknown> {
   };
 }
 
+async function syncImages(args: Args, ctx: AgentContext): Promise<unknown> {
+  const built = await currentImagePlan(args, ctx, true);
+  if (!isBuiltImagePlan(built)) return built;
+  const prepared = buildMusicImagePlacementActions(built.plan, ctx.getState(), ctx.getDoc().assets);
+  if (prepared.missingAssetIds.length) {
+    return {
+      error: 'some planned image assets are no longer in the media pool; rebuild the music image plan',
+      changed: false,
+      missingAssetIds: prepared.missingAssetIds,
+    };
+  }
+  if (prepared.trackLocked) {
+    return {
+      ok: true,
+      changed: false,
+      analysisRef: built.plan.analysisRef,
+      reason: `target video track ${built.plan.track} is locked; unlock it or choose another track`,
+      track: built.plan.track,
+    };
+  }
+  if (prepared.conflictingItemIds.length) {
+    return {
+      error: `target video track ${built.plan.track} is occupied in the requested range; choose an empty track`,
+      changed: false,
+      track: built.plan.track,
+      conflictingItemIds: prepared.conflictingItemIds.slice(0, MAX_MUSIC_PLAN_TARGETS),
+    };
+  }
+  if (!prepared.actions.length) {
+    return {
+      ok: true,
+      changed: false,
+      analysisRef: built.plan.analysisRef,
+      reason: 'no image placements were produced for the requested music range',
+    };
+  }
+  ctx.commands.batch(prepared.actions, '按音乐卡点插入图片');
+  return {
+    ok: true,
+    changed: true,
+    analysisRef: built.plan.analysisRef,
+    track: built.plan.track,
+    placementCount: prepared.actions.length,
+    imageAssetIds: built.plan.imageAssetIds,
+    timing: built.plan.timing,
+    range: built.plan.range,
+  };
+}
+
 export async function execMusicIntelligenceTool(name: string, args: Args, ctx: AgentContext): Promise<unknown> {
   try {
     if (name === 'analyze_music') return await analyzeMusic(args, ctx);
@@ -464,6 +714,11 @@ export async function execMusicIntelligenceTool(name: string, args: Args, ctx: A
       return isBuiltPlan(built) ? planResponse(built) : built;
     }
     if (name === 'sync_cuts_to_music') return await syncCuts(args, ctx);
+    if (name === 'music_image_plan') {
+      const built = await currentImagePlan(args, ctx);
+      return isBuiltImagePlan(built) ? imagePlanResponse(built) : built;
+    }
+    if (name === 'sync_images_to_music') return await syncImages(args, ctx);
     return { error: `unknown tool ${name}` };
   } catch (error) {
     return { error: error instanceof Error ? error.message : String(error) };

--- a/src/agent/tools/music-intelligence-tools.verify.ts
+++ b/src/agent/tools/music-intelligence-tools.verify.ts
@@ -11,6 +11,7 @@ import { ToolActivation } from '../tool-activation';
 import { TOOL_SCHEMAS } from '../tools';
 import {
   buildMusicEditPlan,
+  buildMusicImagePlacementPlan,
   buildMusicSplitActions,
   execMusicIntelligenceTool,
   staleMusicAnalysisResult,
@@ -122,6 +123,11 @@ function state(items: TimelineItem[], tracks: TimelineState['tracks'] = {}): Tim
   });
   assert.equal(staleMusicAnalysisResult('new-ref', 'new-ref'), null);
   assert.equal(staleMusicAnalysisResult(undefined, 'new-ref'), null);
+  assert.deepEqual(staleMusicAnalysisResult('old-ref', 'new-ref', 'music_image_plan'), {
+    error: 'stale music analysisRef; call music_image_plan again before editing',
+    staleAnalysisRef: true,
+    currentAnalysisRef: 'new-ref',
+  });
 }
 
 {
@@ -142,11 +148,117 @@ function state(items: TimelineItem[], tracks: TimelineState['tracks'] = {}): Tim
 }
 
 {
+  const music = item('music', 'audio', 'A1', 0, 120, {
+    src: '/media/uploads/music.wav',
+    sourceAssetId: 'asset_music',
+  });
+  const images = [
+    {
+      id: 'image-a', name: 'A', kind: 'image' as const, src: '/media/uploads/a.png', durationInFrames: 1,
+    },
+    {
+      id: 'image-b', name: 'B', kind: 'image' as const, src: '/media/uploads/b.png', durationInFrames: 1,
+    },
+  ];
+  const built = buildMusicImagePlacementPlan(
+    analysisWith([1_000, 2_000, 3_000]),
+    'image-plan-ref',
+    music,
+    state([music], { V1: { kind: 'video' } }),
+    images,
+    { timing: 'beat', density: 'dense', imageAssetIds: ['image-a', 'image-b'] },
+  );
+  assert.deepEqual(
+    built.plan.placements,
+    [
+      { assetId: 'image-a', startFrame: 0, durationInFrames: 30 },
+      { assetId: 'image-b', startFrame: 30, durationInFrames: 30 },
+      { assetId: 'image-a', startFrame: 60, durationInFrames: 30 },
+      { assetId: 'image-b', startFrame: 90, durationInFrames: 30 },
+    ],
+    'photos must occupy beat-to-beat intervals and cycle deterministically',
+  );
+  assert.throws(
+    () => buildMusicImagePlacementPlan(
+      analysisWith([1_000, 2_000, 3_000]),
+      'image-plan-ref',
+      music,
+      state([music], { V1: { kind: 'video' } }),
+      images,
+      { timing: 'beat', density: 'dense', track: 'V99' },
+    ),
+    /video track "V99" not found/,
+    'an invalid explicit target track must not silently fall back to V1',
+  );
+}
+
+{
+  const music = item('music', 'audio', 'A1', 0, 120, {
+    src: '/media/uploads/music.wav',
+    sourceAssetId: 'asset_music',
+  });
+  const images = [
+    {
+      id: 'image-a', name: 'A', kind: 'image' as const, src: '/media/uploads/a.png', durationInFrames: 1,
+    },
+    {
+      id: 'image-b', name: 'B', kind: 'image' as const, src: '/media/uploads/b.png', durationInFrames: 1,
+    },
+  ];
+  const timeline = state([music], { V1: { kind: 'video' } });
+  const analysis = analysisWith([1_000, 2_000, 3_000]);
+  await saveMusicAnalysis(analysis);
+  const batches: Array<{ actions: AtomicAction[]; label?: string }> = [];
+  const ctx = {
+    getState: () => timeline,
+    getDoc: () => ({
+      schemaVersion: 7,
+      assets: [
+        {
+          id: 'asset_music', name: 'Music', kind: 'audio' as const,
+          src: '/media/uploads/music.wav', durationInFrames: 120, sourceRevision: 'sha256:music',
+        },
+        ...images,
+      ],
+    }),
+    commands: {
+      batch: (actions: AtomicAction[], label?: string) => { batches.push({ actions, label }); },
+    },
+  } as unknown as AgentContext;
+  const stale = await execMusicIntelligenceTool('sync_images_to_music', {
+    itemId: 'music',
+    timing: 'beat',
+    density: 'dense',
+    analysisRef: 'old-image-ref',
+  }, ctx) as { staleAnalysisRef?: boolean };
+  assert.equal(stale.staleAnalysisRef, true);
+  assert.equal(batches.length, 0, 'stale analysis must reject before photo mutation');
+  const result = await execMusicIntelligenceTool('sync_images_to_music', {
+    itemId: 'music',
+    timing: 'beat',
+    density: 'dense',
+    imageAssetIds: ['image-a', 'image-b'],
+    analysisRef: musicAnalysisRef(analysis),
+  }, ctx) as { changed?: boolean; placementCount?: number };
+  assert.equal(result.changed, true);
+  assert.equal(result.placementCount, 4);
+  assert.equal(batches.length, 1, 'all photo placements must be one EditorCommands batch/undo step');
+  assert.deepEqual(
+    batches[0]?.actions.map((action) => action.type === 'add'
+      ? [action.startFrame, action.item.durationInFrames, action.item.sourceAssetId]
+      : null),
+    [[0, 30, 'image-a'], [30, 30, 'image-b'], [60, 30, 'image-a'], [90, 30, 'image-b']],
+  );
+}
+
+{
   const askNames = ASK_MODE_TOOL_SCHEMAS.map((schema) => schema.name);
   assert.ok(askNames.includes('analyze_music'));
   assert.ok(askNames.includes('inspect_music'));
   assert.ok(askNames.includes('music_edit_plan'));
+  assert.ok(askNames.includes('music_image_plan'));
   assert.equal(askNames.includes('sync_cuts_to_music'), false, 'Q&A mode must not expose the mutating tool');
+  assert.equal(askNames.includes('sync_images_to_music'), false, 'Q&A mode must not expose the mutating photo tool');
   const routed = new ToolActivation(
     TOOL_SCHEMAS,
     [{ role: 'user', content: '请根据 BGM 卡点剪辑这些视频' }],
@@ -155,7 +267,15 @@ function state(items: TimelineItem[], tracks: TimelineState['tracks'] = {}): Tim
   assert.ok(routed.includes('inspect_music'));
   assert.ok(routed.includes('music_edit_plan'));
   assert.ok(routed.includes('sync_cuts_to_music'));
+  const photoRouted = new ToolActivation(
+    TOOL_SCHEMAS,
+    [{ role: 'user', content: '按音乐节拍把这些照片卡点排布' }],
+  ).names();
+  assert.ok(photoRouted.includes('analyze_music'));
+  assert.ok(photoRouted.includes('music_image_plan'));
+  assert.ok(photoRouted.includes('sync_images_to_music'));
   assert.deepEqual(policyForTool('analyze_music'), { effect: 'read', recovery: 'pure' });
+  assert.deepEqual(policyForTool('music_image_plan'), { effect: 'read', recovery: 'pure' });
 }
 
 
@@ -267,6 +387,46 @@ function state(items: TimelineItem[], tracks: TimelineState['tracks'] = {}): Tim
     assert.ok(result.error!.includes('设置 → 转写 → 本地模型'), 'error must carry the settings guidance (zh)');
     assert.ok(result.error!.includes('Settings → Transcription → Local models'), 'error must carry the settings guidance (en)');
     assert.equal(result.modelPacks?.length, 2, 'the missing pack ids must be reported');
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+}
+
+// ── music_image_plan builds on the analyze_music pipeline: no implicit analysis ──
+{
+  const music = item('music', 'audio', 'A1', 0, 120, {
+    src: '/media/uploads/music.wav',
+    sourceAssetId: 'asset_music_uncached',
+  });
+  const timeline = state([music], { V1: { kind: 'video' } });
+  const ctx = {
+    getState: () => timeline,
+    getDoc: () => ({
+      schemaVersion: 7,
+      assets: [
+        {
+          id: 'asset_music_uncached', name: 'Music', kind: 'audio' as const,
+          src: '/media/uploads/music.wav', durationInFrames: 120, sourceRevision: 'sha256:uncached',
+        },
+      ],
+    }),
+    commands: { batch: () => { throw new Error('must not mutate'); } },
+  } as unknown as AgentContext;
+  const previousFetch = globalThis.fetch;
+  const catalogResponse = new Response(JSON.stringify({
+    packs: [
+      { id: 'rhythm-lite', status: 'installed' },
+      { id: 'music-semantics-lite', status: 'installed' },
+    ],
+  }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  globalThis.fetch = (async () => catalogResponse) as typeof fetch;
+  try {
+    const result = await execMusicIntelligenceTool('music_image_plan', {
+      itemId: 'music', timing: 'beat', density: 'dense',
+    }, ctx) as { error?: string; requiredModelPacks?: string[] };
+    assert.ok(result.error, 'a missing cache must reject the plan instead of starting analysis');
+    assert.ok(result.error!.includes('not been analyzed'), 'the error must point at the analyze_music entry point');
+    assert.deepEqual(result.requiredModelPacks, ['rhythm-lite', 'music-semantics-lite']);
   } finally {
     globalThis.fetch = previousFetch;
   }

--- a/src/agent/tools/schemas/music-intelligence-tools.ts
+++ b/src/agent/tools/schemas/music-intelligence-tools.ts
@@ -44,6 +44,43 @@ const PLAN_PROPERTIES = {
   },
 } as const;
 
+const IMAGE_PLAN_PROPERTIES = {
+  itemId: {
+    type: 'string',
+    description: 'BGM timeline audio/video clip id (unique prefix accepted).',
+  },
+  timing: {
+    type: 'string',
+    enum: ['auto', 'beat', 'downbeat', 'section'],
+    description: 'Photo-change timing. auto chooses section/downbeat/beat deterministically from density and available analysis.',
+  },
+  density: {
+    type: 'string',
+    enum: ['sparse', 'medium', 'dense'],
+    description: 'How many analyzed timing points to retain.',
+  },
+  fromFrame: {
+    type: 'number',
+    minimum: 0,
+    description: 'Optional inclusive timeline-frame range start; defaults to the BGM clip start.',
+  },
+  toFrame: {
+    type: 'number',
+    minimum: 1,
+    description: 'Optional exclusive timeline-frame range end; defaults to the BGM clip end.',
+  },
+  imageAssetIds: {
+    type: 'array',
+    items: { type: 'string' },
+    maxItems: 64,
+    description: 'Optional image asset ids/prefixes in display order. Defaults to all image assets in media-pool order and cycles when needed.',
+  },
+  track: {
+    type: 'string',
+    description: 'Optional target video track id or alias, default V1. The target range must be empty and unlocked.',
+  },
+} as const;
+
 export const MUSIC_INTELLIGENCE_TOOL_SCHEMAS: AgentToolSchema[] = [
   {
     name: 'analyze_music',
@@ -103,6 +140,38 @@ export const MUSIC_INTELLIGENCE_TOOL_SCHEMAS: AgentToolSchema[] = [
         analysisRef: {
           type: 'string',
           description: 'Opaque ref from music_edit_plan. Execution rejects missing or stale analysis.',
+        },
+      },
+      required: ['itemId', 'timing', 'density', 'analysisRef'],
+    },
+  },
+  {
+    name: 'music_image_plan',
+    description: [
+      'Build a deterministic, read-only photo placement plan from cached music analysis and the BGM clip trim/speed mapping.',
+      'The plan fills the requested range with media-pool images, changing images at beat/downbeat/section boundaries and cycling the selected image order.',
+      'Call this before sync_images_to_music so the user can review the bounded placement plan. This tool never starts analysis.',
+    ].join(' '),
+    input_schema: {
+      type: 'object',
+      properties: IMAGE_PLAN_PROPERTIES,
+      required: ['itemId', 'timing', 'density'],
+    },
+  },
+  {
+    name: 'sync_images_to_music',
+    description: [
+      'Recompute a cached music image plan and add one image clip per planned beat interval.',
+      'Pass the analysisRef returned by music_image_plan to reject stale analysis. All image additions are one EditorCommands batch and one undo step.',
+      'The target video track must be unlocked and empty in the requested range; this never starts analysis and never edits the BGM clip.',
+    ].join(' '),
+    input_schema: {
+      type: 'object',
+      properties: {
+        ...IMAGE_PLAN_PROPERTIES,
+        analysisRef: {
+          type: 'string',
+          description: 'Opaque ref from music_image_plan. Execution rejects missing or stale analysis.',
         },
       },
       required: ['itemId', 'timing', 'density', 'analysisRef'],


### PR DESCRIPTION
Fixes #55

## Summary
- Add `music_image_plan` and `sync_images_to_music` for deterministic photo placement on BGM beat, downbeat, or section boundaries.
- Cycle explicitly selected image assets in order, fill the complete requested range, and apply all image additions as one undoable batch.
- Guard against stale music analysis, missing assets, locked tracks, and occupied target ranges.
- Add regression coverage for the Windows desktop provenance path `D:\Fun\Music\小城夏天.mp3`; `originalFilePath` remains relink metadata and is not treated as a render source during export preflight.

## Root cause
The existing music editing tools only split video clips. Photo insertion therefore fell back to normal media placement instead of deriving clip durations from beat intervals, which produced uniform photo timing. The desktop export preflight also needs to ignore `originalFilePath`, because it points to the original NLE file rather than the renderer-visible `src`.

## Validation
- `npx tsx src/agent/tools/music-intelligence-tools.verify.ts`
- `npx tsx src/export/exportMediaPlan.verify.ts`
- `npx tsx src/agent/tool-activation.verify.ts`
- `npm run verify:skills`
- `npm run verify:agent-tools`
- `npm run verify:server-tool-catalog`
- `npx tsc -p tsconfig.app.json --noEmit --pretty false`
- Targeted `oxlint` on changed TypeScript files