### PR TITLE
fix(i18n): localize media view toggle tooltip

### DIFF
--- a/src/media/media-view-toggle.verify.ts
+++ b/src/media/media-view-toggle.verify.ts
@@ -1,9 +1,14 @@
 import assert from 'node:assert/strict';
+import englishMedia from '../i18n/dict/en/media';
 import { mediaViewToggleLabel, toggleMediaView } from './mediaView';
 
-assert.equal(mediaViewToggleLabel('list'), '切换至网格视图');
+assert.equal(mediaViewToggleLabel('list'), '切换到网格视图');
 assert.equal(toggleMediaView('list'), 'grid');
-assert.equal(mediaViewToggleLabel('grid'), '切换至列表视图');
+assert.equal(mediaViewToggleLabel('grid'), '切换到列表视图');
 assert.equal(toggleMediaView('grid'), 'list');
+for (const view of ['grid', 'list'] as const) {
+  const label = mediaViewToggleLabel(view);
+  assert.ok(englishMedia[label], `English media dictionary must contain the view-toggle label: ${label}`);
+}
 
 console.log('media view toggle verification passed');

--- a/src/media/mediaView.ts
+++ b/src/media/mediaView.ts
@@ -4,6 +4,6 @@ export function toggleMediaView(view: MediaView): MediaView {
   return view === 'grid' ? 'list' : 'grid';
 }
 
-export function mediaViewToggleLabel(view: MediaView): '切换至网格视图' | '切换至列表视图' {
-  return view === 'grid' ? '切换至列表视图' : '切换至网格视图';
+export function mediaViewToggleLabel(view: MediaView): '切换到网格视图' | '切换到列表视图' {
+  return view === 'grid' ? '切换到列表视图' : '切换到网格视图';
 }


### PR DESCRIPTION
## Summary

- align the media view-toggle labels with the existing English dictionary keys
- add a regression check ensuring every dynamic view-toggle label has an English translation

## Root cause

`mediaViewToggleLabel()` returned keys using `切换至…视图`, while the English media dictionary registers `切换到…视图`. Because Chinese source strings are used as translation keys, the lookup missed and fell back to Chinese in the English interface.

## User impact

The grid/list toggle tooltip now displays **Switch to list view** or **Switch to grid view** when the application language is English.

Fixes #73

## Validation

- `npx tsx src/media/media-view-toggle.verify.ts`
- `npx tsx src/media/media-toolbar-tooltips.verify.tsx`
- `npm run verify:i18n`
- TypeScript project build
- Vite production build
