### PR TITLE
Fix source-free clips rebounding after left trim

### DIFF
--- a/src/components/timeline/useTimelinePointer.ts
+++ b/src/components/timeline/useTimelinePointer.ts
@@ -112,23 +112,35 @@ function commitTrimGesture(
   if (mode === 'trim-left') {
     const target = state.items.find((item) => item.id === id);
     if (!target) return;
+    const sourceTimed = target.kind === 'video' || target.kind === 'audio' || target.kind === 'sequence';
     const wordDriven = target.kind === 'audio' && hasOperationalTranscript(target);
-    const sourceBacktrack = wordDriven
-      ? baseSrcIn
-      : sourceFramesToTimelineFrames(target, baseSrcIn);
-    const earliestDelta = Math.max(-baseStart, -Math.floor(sourceBacktrack));
+    let earliestDelta = -baseStart;
+    if (sourceTimed) {
+      const sourceBacktrack = wordDriven
+        ? baseSrcIn
+        : sourceFramesToTimelineFrames(target, baseSrcIn);
+      earliestDelta = Math.max(earliestDelta, -Math.floor(sourceBacktrack));
+    }
     const delta = Math.max(Math.min(deltaF, baseDur - 1), earliestDelta);
-    if (delta !== 0) commands.setItemTiming(id, {
+    if (delta === 0) return;
+    const timing = {
       startFrame: baseStart + delta,
       durationInFrames: baseDur - delta,
-      srcInFrame: wordDriven
-        ? sourceWindowForTimelineRange({ srcInFrame: baseSrcIn, playbackRate: 1 }, delta, baseDur - delta).startFrame
-        : sourceWindowForTimelineRange(
-            { ...target, srcInFrame: baseSrcIn },
-            delta,
-            baseDur - delta,
-          ).startFrame,
-    });
+      ...(sourceTimed ? {
+        srcInFrame: wordDriven
+          ? sourceWindowForTimelineRange(
+              { srcInFrame: baseSrcIn, playbackRate: 1 },
+              delta,
+              baseDur - delta,
+            ).startFrame
+          : sourceWindowForTimelineRange(
+              { ...target, srcInFrame: baseSrcIn },
+              delta,
+              baseDur - delta,
+            ).startFrame,
+      } : {}),
+    };
+    commands.setItemTiming(id, timing);
     return;
   }
   const durationInFrames = Math.max(1, baseDur + deltaF);

--- a/src/components/timeline/useTimelinePointer.verify.ts
+++ b/src/components/timeline/useTimelinePointer.verify.ts
@@ -109,6 +109,26 @@ assert.deepEqual(
   'timeline-head clamp adjusts the effective delta so the right edge remains fixed',
 );
 
+for (const kind of ['image', 'gif', 'svg', 'motion-graphic', 'text', 'solid'] as const) {
+  calls.length = 0;
+  const extensibleState: TimelineState = {
+    ...state,
+    items: [{ ...state.items[0]!, kind, srcInFrame: undefined }],
+  };
+  commitTimelineDragGesture(extensibleState, commands, {
+    ...drag,
+    mode: 'trim-left',
+    baseSrcIn: 0,
+    deltaF: -10,
+  }, 'selection');
+  assert.equal(calls[0]?.method, 'setItemTiming', `${kind} left extension commits one retime`);
+  assert.deepEqual(
+    calls[0]?.args,
+    ['clip-a', { startFrame: 90, durationInFrames: 60 }],
+    `${kind} has no source in-point, so empty timeline space is valid trim handle`,
+  );
+}
+
 calls.length = 0;
 commitTimelineDragGesture(state, commands, {
   ...drag,


### PR DESCRIPTION
## Summary

- allow image, GIF, SVG, motion graphic, text, and solid clips to extend from the left when timeline space is available
- preserve source in-point limits for video, audio, and nested sequence clips
- add regression coverage for every source-free clip kind affected by the rebound

## Root cause

The left-trim commit path always clamped the requested delta against `srcInFrame` and always submitted a new source in-point. Source-free clips normally have `srcInFrame = 0`, so their valid left extension was reduced to zero on pointer release even though the drag preview showed the requested geometry.

## User impact

Source-free clips now keep their new start position and duration after the left trim handle is released. Existing right trim, ripple trim, rate stretch, slip, and source-timed media behavior remain unchanged.

## Validation

- `npx tsx --tsconfig tsconfig.app.json src/components/timeline/useTimelinePointer.verify.ts`
- `npx tsc -b`
- `npm run lint`
- `npm run build`
- `npm run test:contrib-timeline-preview`
- `npx tsx src/editor/sourceLimit.verify.ts`

Fixes #75
