### PR TITLE
test(external-agent): cover direct-touch lease refresh

### DIFF
--- a/server/external-agent/broker-poll-refresh.verify.ts
+++ b/server/external-agent/broker-poll-refresh.verify.ts
@@ -5,6 +5,7 @@ import {
   nextEditorCall,
   registerEditor,
   resetExternalAgentBrokerForTest,
+  touchEditor,
 } from './broker.ts';
 
 const projectId = 'project-poll-refresh';
@@ -44,6 +45,31 @@ try {
     isProjectConnected(projectId),
     true,
     'a long-poll refreshes lastSeen before the editor online lease expires',
+  );
+} finally {
+  mock.timers.reset();
+  resetExternalAgentBrokerForTest();
+}
+
+// Direct-touch scenario: bridge routes touch the editor outside the long-poll
+// wait loop (poll entry, tool settle). A validated touch must refresh the
+// online lease too, or an idle editor drops out of isConnected() after
+// ONLINE_MS while its registration still blocks the offline fallback.
+resetExternalAgentBrokerForTest();
+mock.timers.enable({ apis: ['Date', 'setTimeout'] });
+try {
+  const registrationCapability = registerEditor(projectId, editorId, revision, tools, undefined, null);
+  mock.timers.setTime(30_000);
+  assert.equal(
+    await touchEditor(projectId, editorId, revision, registrationCapability),
+    true,
+    'touch accepts the registered editor',
+  );
+  mock.timers.setTime(60_000);
+  assert.equal(
+    isProjectConnected(projectId),
+    true,
+    'a validated touch refreshes the editor online lease',
   );
 } finally {
   mock.timers.reset();

--- a/server/external-agent/broker-registry.ts
+++ b/server/external-agent/broker-registry.ts
@@ -187,7 +187,7 @@ export class EditorConnectionRegistry {
     // lease (isConnected) reflects this poll even when no call arrives.
     editor.lastSeen = Date.now();
     return true;
-}
+  }
 
   registrationMatches(
     projectId: string,


### PR DESCRIPTION
> **Reworked after c6d1c1d.** This PR originally carried the same `lastSeen` fix, submitted about half an hour after c6d1c1d landed it upstream — we found the bug independently through the MCP deadlock it causes (`begin_edit_session` → "No OpenChatCut editor is connected" while `target_project`'s offline fallback stays blocked, the symptom reported in #63). The fix being upstream now, this PR keeps the part c6d1c1d does not have: test coverage for the direct-touch path, plus a tiny formatting restore.

## What this adds

**A direct-touch scenario in `broker-poll-refresh.verify.ts`.** The existing scenario exercises the lease refresh through `nextEditorCall`'s wait loop. Bridge routes also touch the editor outside that loop (poll entry, tool settle); this scenario pins the lease semantics on `touchEditor` itself: register → touch at +30s → editor must still be connected at +60s. If a future refactor moves the `lastSeen` refresh back out of `touch()`, this fails even when the long-poll path happens to compensate.

**Brace indent restore.** c6d1c1d left `touch()`'s closing brace at column zero; restored to the surrounding two-space style.

## Verification

- `tsx server/external-agent/broker-poll-refresh.verify.ts` → ok (both scenarios)
- `tsx server/external-agent/broker.verify.ts` → passes
- `oxlint` on touched files → clean

One observation from the original investigation, in case it is useful: `run-affected-verifies` reports `no affected verifies` when only `broker-registry.ts` or `broker-poll-refresh.verify.ts` change, which is how #70's failing guard could slip through a PR run. Happy to look at wiring those files into the affected map in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)