### PR TITLE
feat(storage): let the user choose where projects are stored

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "verify:affected": "node scripts/run-affected-verifies.mjs",
     "verify:media-drag": "tsx src/media/drag.verify.ts",
     "verify:semantic-sampling": "tsx src/media/semantic-search/samplingConfig.verify.ts",
-    "verify:runtime-profile": "node scripts/dev-profile.verify.mjs && tsx server/runtime-profile.verify.ts && tsx desktop/runtime-profile.verify.ts && tsx server/keystore-profile.verify.ts && tsx server/media-dir-profile.verify.ts && tsx server/r2-profile.verify.ts",
+    "verify:runtime-profile": "node scripts/dev-profile.verify.mjs && tsx server/runtime-profile.verify.ts && tsx desktop/runtime-profile.verify.ts && tsx server/keystore-profile.verify.ts && tsx server/media-dir-profile.verify.ts && tsx server/data-dir.verify.ts && tsx server/r2-profile.verify.ts",
     "verify:directory-watch": "tsx shared/directory-import.verify.ts && tsx desktop/directory-watch-errors.verify.ts && tsx desktop/directory-watch-controller.verify.ts && tsx desktop/directory-watch-import.verify.ts && tsx desktop/directory-watch.verify.ts && tsx src/media/directoryDrop.verify.ts && tsx src/media/directoryImportAsset.verify.ts && tsx src/media/useDirectoryImport.verify.ts && tsx src/media/directoryImportIntegration.verify.ts && tsx src/media/media-folder-menu.verify.ts && tsx src/media/media-pool-batch-timeline.verify.ts",
     "verify:clip-fx-export": "node src/gl/clipFxExport.verify.mjs",
     "verify:approval-policy": "tsx src/agent/approval-policy.verify.ts",

--- a/server/data-dir.ts
+++ b/server/data-dir.ts
@@ -7,9 +7,9 @@
 // would require already knowing the root. It is therefore recorded in a small
 // pointer file at a fixed location that never moves.
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
-import { cp, mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
+import { cp, mkdir, readdir, rename, rm, unlink, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { isAbsolute, join, resolve } from 'node:path';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 
 /** Fixed pointer location — deliberately outside the movable storage root. */
 export function dataDirPointerPath(home: string = homedir()): string {
@@ -122,7 +122,22 @@ export async function relocateDataDir(
         continue;
       }
     }
-    await cp(from, to, { recursive: true, force: false, errorOnExist: false });
+    // Copy aside, then rename into place. A relocation interrupted midway (disk
+    // full, power loss, quit) must never leave a half-copied store looking
+    // complete: the entry either exists whole or not at all, so the next attempt
+    // sees an absent destination and retries from scratch instead of adopting a
+    // partial one. Leftover staging directories are cleaned up on the retry.
+    const staging = `${to}.incoming`;
+    await rm(staging, { recursive: true, force: true });
+    await mkdir(dirname(to), { recursive: true });
+    try {
+      await cp(from, staging, { recursive: true, force: false, errorOnExist: false });
+      await rm(to, { recursive: true, force: true });
+      await rename(staging, to);
+    } catch (error) {
+      await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+      throw error;
+    }
     copiedEntries += 1;
   }
   if (copiedEntries > 0) log(`[data-dir] copied ${copiedEntries} entries: ${source} → ${target}`);

--- a/server/data-dir.ts
+++ b/server/data-dir.ts
@@ -70,26 +70,47 @@ export async function checkDataDir(raw: string, currentDir: string): Promise<Dat
   }
 }
 
-/** Storage-root contents that must travel with a relocation. Anything else in
- *  the root (logs, caches) is regenerated and deliberately left behind. */
+/** Root-level entries that travel with a relocation. Media is NOT here: in the
+ *  default profile uploads live outside the root (checkout `public/media/uploads`
+ *  or packaged `userData/...`), so it is copied separately from the resolved
+ *  upload directory. Anything else in the root is regenerated and left behind. */
 const RELOCATED_ENTRIES = [
   'project-store-v1',
   'project-store-v1.json',
   'project-store-auth-v1',
-  'media',
   'deleted-projects-v1.json',
   'generation-operations-v1.json',
 ] as const;
 
+/** Why a relocation was refused, so the caller can explain it to the user. */
+export type RelocationRefusal = 'sqlite-store-active';
+
+export interface RelocationOutcome {
+  refused?: RelocationRefusal;
+  copiedEntries: number;
+}
+
 /** Copy the current storage root into a newly chosen one. The source is left
- *  untouched: a relocation must never be the step that loses the projects. */
+ *  untouched: a relocation must never be the step that loses the projects.
+ *
+ *  Refuses outright while the SQLite store is the authority. That database is
+ *  the whole project store (documents, FTS, semantic vectors) plus its import
+ *  receipt, and copying a live WAL-mode database with a plain file copy can
+ *  produce a torn snapshot. Moving it safely needs a quiesced backup taken
+ *  under the store lock, which belongs in a follow-up rather than behind a
+ *  settings field that looks harmless. */
 export async function relocateDataDir(
   source: string,
   target: string,
   log: (msg: string) => void,
-): Promise<number> {
-  if (source === target) return 0;
-  let copied = 0;
+  sqliteActive: boolean,
+): Promise<RelocationOutcome> {
+  if (source === target) return { copiedEntries: 0 };
+  if (sqliteActive) {
+    log('[data-dir] relocation refused: the SQLite project store is active');
+    return { refused: 'sqlite-store-active', copiedEntries: 0 };
+  }
+  let copiedEntries = 0;
   for (const entry of RELOCATED_ENTRIES) {
     const from = join(source, entry);
     if (!existsSync(from)) continue;
@@ -97,15 +118,21 @@ export async function relocateDataDir(
     if (existsSync(to)) {
       const existing = await readdir(to).catch(() => ['?']);
       if (existing.length > 0) {
-        log(`[data-dir] 跳过已存在的 ${entry}（目标目录非空，不覆盖）`);
+        log(`[data-dir] skipped ${entry}: already present in the new directory`);
         continue;
       }
     }
     await cp(from, to, { recursive: true, force: false, errorOnExist: false });
-    copied += 1;
+    copiedEntries += 1;
   }
-  if (copied > 0) log(`[data-dir] 已复制 ${copied} 项到新目录：${source} → ${target}`);
-  return copied;
+  if (copiedEntries > 0) log(`[data-dir] copied ${copiedEntries} entries: ${source} → ${target}`);
+  return { copiedEntries };
+}
+
+/** Upload directory the relocated root will resolve to, so the caller can copy
+ *  the existing media into it. Mirrors uploadDir()'s layout for a chosen root. */
+export function relocatedUploadDir(target: string): string {
+  return join(target, 'media', 'uploads');
 }
 
 /** Create the storage root up-front so a first run never races the first write. */

--- a/server/data-dir.ts
+++ b/server/data-dir.ts
@@ -1,0 +1,114 @@
+// User-chosen storage root ("games-style save folder"): projects, versions and
+// media live where the user asks, so removing or reinstalling the app never
+// touches their work.
+//
+// The chosen path CANNOT live in the settings keystore: in an isolated dev
+// profile the keystore file itself sits inside the storage root, so reading it
+// would require already knowing the root. It is therefore recorded in a small
+// pointer file at a fixed location that never moves.
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { cp, mkdir, readdir, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { isAbsolute, join, resolve } from 'node:path';
+
+/** Fixed pointer location — deliberately outside the movable storage root. */
+export function dataDirPointerPath(home: string = homedir()): string {
+  return join(home, '.openchatcut', 'data-dir.json');
+}
+
+/** Expand ~/ and require an absolute path; anything else is rejected. */
+export function expandDataDir(raw: string, home: string = homedir()): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const expanded = trimmed === '~' ? home : trimmed.replace(/^~(?=\/)/, home);
+  if (!isAbsolute(expanded)) return null;
+  return resolve(expanded);
+}
+
+/** Recorded storage root, or null when the app uses its default location.
+ *  Synchronous: the runtime profile resolves at module load. A malformed
+ *  pointer degrades to the default rather than blocking startup. */
+export function readDataDirPointer(home: string = homedir()): string | null {
+  const pointer = dataDirPointerPath(home);
+  if (!existsSync(pointer)) return null;
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(pointer, 'utf8'));
+    if (!parsed || typeof parsed !== 'object') return null;
+    const value = (parsed as { dataDir?: unknown }).dataDir;
+    return typeof value === 'string' ? expandDataDir(value, home) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Record the storage root, or clear it (empty value) to return to the default. */
+export async function writeDataDirPointer(dir: string | null, home: string = homedir()): Promise<void> {
+  const pointer = dataDirPointerPath(home);
+  await mkdir(join(home, '.openchatcut'), { recursive: true });
+  if (!dir) {
+    await unlink(pointer).catch(() => undefined);
+    return;
+  }
+  await writeFile(pointer, `${JSON.stringify({ version: 1, dataDir: dir }, null, 2)}\n`, { mode: 0o600 });
+}
+
+export interface DataDirProbe { ok: boolean; note?: string; error?: string; }
+
+/** Writability probe for the settings "test" action and for save-time validation. */
+export async function checkDataDir(raw: string, currentDir: string): Promise<DataDirProbe> {
+  if (!raw.trim()) return { ok: true, note: `未设置 · 使用默认目录 ${currentDir}` };
+  const dir = expandDataDir(raw);
+  if (!dir) return { ok: false, error: '必须是绝对路径（可用 ~/ 开头）' };
+  try {
+    await mkdir(dir, { recursive: true });
+    const probe = join(dir, `.cc-data-probe-${process.pid}`);
+    await writeFile(probe, 'ok');
+    await unlink(probe);
+    return { ok: true, note: `目录可写 · ${dir}` };
+  } catch (err) {
+    return { ok: false, error: `目录不可写 · ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
+/** Storage-root contents that must travel with a relocation. Anything else in
+ *  the root (logs, caches) is regenerated and deliberately left behind. */
+const RELOCATED_ENTRIES = [
+  'project-store-v1',
+  'project-store-v1.json',
+  'project-store-auth-v1',
+  'media',
+  'deleted-projects-v1.json',
+  'generation-operations-v1.json',
+] as const;
+
+/** Copy the current storage root into a newly chosen one. The source is left
+ *  untouched: a relocation must never be the step that loses the projects. */
+export async function relocateDataDir(
+  source: string,
+  target: string,
+  log: (msg: string) => void,
+): Promise<number> {
+  if (source === target) return 0;
+  let copied = 0;
+  for (const entry of RELOCATED_ENTRIES) {
+    const from = join(source, entry);
+    if (!existsSync(from)) continue;
+    const to = join(target, entry);
+    if (existsSync(to)) {
+      const existing = await readdir(to).catch(() => ['?']);
+      if (existing.length > 0) {
+        log(`[data-dir] 跳过已存在的 ${entry}（目标目录非空，不覆盖）`);
+        continue;
+      }
+    }
+    await cp(from, to, { recursive: true, force: false, errorOnExist: false });
+    copied += 1;
+  }
+  if (copied > 0) log(`[data-dir] 已复制 ${copied} 项到新目录：${source} → ${target}`);
+  return copied;
+}
+
+/** Create the storage root up-front so a first run never races the first write. */
+export function ensureDataDir(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+}

--- a/server/data-dir.verify.ts
+++ b/server/data-dir.verify.ts
@@ -1,0 +1,120 @@
+// checks:data-dir pure logic - path expansion, the pointer file round trip and its
+// degradation, the writability probe, and relocation safety. Every case runs inside a
+// temporary fixture home: nothing reads the developer's real storage root, and no
+// network request exists in this file.
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  checkDataDir,
+  dataDirPointerPath,
+  ensureDataDir,
+  expandDataDir,
+  readDataDirPointer,
+  relocateDataDir,
+  writeDataDirPointer,
+} from './data-dir.ts';
+
+const fixture = await mkdtemp(join(tmpdir(), 'openchatcut-data-dir-'));
+try {
+  const home = join(fixture, 'home');
+  await mkdir(home, { recursive: true });
+
+  // 1. Expansion: `~/` and a bare `~` resolve against the given home, the result is
+  // normalized, and anything that is not absolute afterwards is rejected rather than
+  // silently resolved against the current working directory.
+  assert.equal(expandDataDir('  ~/Saves  ', home), join(home, 'Saves'));
+  assert.equal(expandDataDir('~', home), home);
+  assert.equal(expandDataDir(join(fixture, 'a', '..', 'b'), home), join(fixture, 'b'));
+  assert.equal(expandDataDir('relative/saves', home), null);
+  assert.equal(expandDataDir('   ', home), null);
+  assert.equal(expandDataDir('~someoneelse/saves', home), null); // `~` only expands before a slash
+
+  // 2. Pointer file: fixed location outside the movable root, written 0600, read back
+  // expanded, and cleared by an empty value (twice in a row must not throw).
+  assert.equal(dataDirPointerPath(home), join(home, '.openchatcut', 'data-dir.json'));
+  assert.equal(readDataDirPointer(home), null);
+  const chosen = join(fixture, 'chosen');
+  await writeDataDirPointer(chosen, home);
+  assert.equal(readDataDirPointer(home), chosen);
+  assert.equal((await stat(dataDirPointerPath(home))).mode & 0o777, 0o600);
+  await writeDataDirPointer(null, home);
+  assert.equal(readDataDirPointer(home), null);
+  await writeDataDirPointer(null, home);
+
+  // 3. A damaged pointer degrades to the default root instead of blocking startup:
+  // startup resolves the profile synchronously and has nowhere to report an error.
+  const pointer = dataDirPointerPath(home);
+  await writeFile(pointer, 'not json at all');
+  assert.equal(readDataDirPointer(home), null);
+  await writeFile(pointer, JSON.stringify({ version: 1 }));
+  assert.equal(readDataDirPointer(home), null);
+  await writeFile(pointer, JSON.stringify({ version: 1, dataDir: 42 }));
+  assert.equal(readDataDirPointer(home), null);
+  await writeFile(pointer, JSON.stringify({ version: 1, dataDir: 'relative/saves' }));
+  assert.equal(readDataDirPointer(home), null);
+  await writeFile(pointer, JSON.stringify({ version: 1, dataDir: '~/Saves' }));
+  assert.equal(readDataDirPointer(home), join(home, 'Saves'));
+  await writeDataDirPointer(null, home);
+
+  // 4. Writability probe: an empty value is legal and names the default root; a relative
+  // path fails without creating anything; a valid path is created and left empty.
+  const unset = await checkDataDir('  ', '/default/root');
+  assert.equal(unset.ok, true);
+  assert.match(unset.note ?? '', /默认目录 \/default\/root/);
+
+  const relative = await checkDataDir('relative/saves', '/default/root');
+  assert.equal(relative.ok, false);
+  assert.match(relative.error ?? '', /绝对路径/);
+  assert.equal(existsSync(join(process.cwd(), 'relative')), false, 'a rejected path must not be created');
+
+  const probeTarget = join(fixture, 'probe-target');
+  const probed = await checkDataDir(probeTarget, '/default/root');
+  assert.equal(probed.ok, true);
+  assert.match(probed.note ?? '', /目录可写/);
+  assert.deepEqual(await readdir(probeTarget), [], 'the probe file is removed after the check');
+
+  const blocked = join(fixture, 'blocked');
+  await writeFile(blocked, 'a file where a directory is expected');
+  const blockedProbe = await checkDataDir(blocked, '/default/root');
+  assert.equal(blockedProbe.ok, false);
+  assert.match(blockedProbe.error ?? '', /目录不可写/);
+
+  // 5. Relocation copies the store entries, leaves regenerated files behind, and never
+  // deletes the source: moving the storage root must not be the step that loses projects.
+  const source = join(fixture, 'source');
+  await mkdir(join(source, 'project-store-v1'), { recursive: true });
+  await writeFile(join(source, 'project-store-v1', 'projects.json'), '[]');
+  await mkdir(join(source, 'media', 'uploads'), { recursive: true });
+  await writeFile(join(source, 'media', 'uploads', 'clip.mp4'), 'video');
+  await writeFile(join(source, 'deleted-projects-v1.json'), '{}');
+  await writeFile(join(source, 'export-cache.log'), 'regenerated, stays behind');
+
+  const logs: string[] = [];
+  const destination = join(fixture, 'destination');
+  assert.equal(await relocateDataDir(source, destination, (msg) => logs.push(msg)), 3);
+  assert.equal(await readFile(join(destination, 'media', 'uploads', 'clip.mp4'), 'utf8'), 'video');
+  assert.equal(await readFile(join(destination, 'project-store-v1', 'projects.json'), 'utf8'), '[]');
+  assert.ok(existsSync(join(source, 'media', 'uploads', 'clip.mp4')), 'the source is kept intact');
+  assert.equal(existsSync(join(destination, 'export-cache.log')), false, 'regenerated files are not carried over');
+  assert.equal(await relocateDataDir(source, source, () => { throw new Error('no log expected'); }), 0);
+
+  // 6. A second relocation into a populated destination overwrites nothing and says so.
+  await writeFile(join(destination, 'deleted-projects-v1.json'), 'newer, must win');
+  const again = await relocateDataDir(source, destination, (msg) => logs.push(msg));
+  assert.equal(again, 0);
+  assert.equal(await readFile(join(destination, 'deleted-projects-v1.json'), 'utf8'), 'newer, must win');
+  assert.ok(logs.some((msg) => msg.includes('跳过已存在的')), 'a skipped entry is reported, never silent');
+
+  // 7. Creating the root up front is idempotent, so a first run never races a first write.
+  const eager = join(fixture, 'eager', 'nested');
+  ensureDataDir(eager);
+  ensureDataDir(eager);
+  assert.ok(existsSync(eager));
+} finally {
+  await rm(fixture, { recursive: true, force: true });
+}
+
+console.log('data-dir.verify OK');

--- a/server/data-dir.verify.ts
+++ b/server/data-dir.verify.ts
@@ -14,6 +14,7 @@ import {
   expandDataDir,
   readDataDirPointer,
   relocateDataDir,
+  relocatedUploadDir,
   writeDataDirPointer,
 } from './data-dir.ts';
 
@@ -84,29 +85,49 @@ try {
 
   // 5. Relocation copies the store entries, leaves regenerated files behind, and never
   // deletes the source: moving the storage root must not be the step that loses projects.
+  // Media is deliberately NOT in the copied set: in the default profile uploads live
+  // outside the root, so the caller copies them from the resolved upload directory.
   const source = join(fixture, 'source');
   await mkdir(join(source, 'project-store-v1'), { recursive: true });
   await writeFile(join(source, 'project-store-v1', 'projects.json'), '[]');
-  await mkdir(join(source, 'media', 'uploads'), { recursive: true });
-  await writeFile(join(source, 'media', 'uploads', 'clip.mp4'), 'video');
   await writeFile(join(source, 'deleted-projects-v1.json'), '{}');
   await writeFile(join(source, 'export-cache.log'), 'regenerated, stays behind');
 
   const logs: string[] = [];
   const destination = join(fixture, 'destination');
-  assert.equal(await relocateDataDir(source, destination, (msg) => logs.push(msg)), 3);
-  assert.equal(await readFile(join(destination, 'media', 'uploads', 'clip.mp4'), 'utf8'), 'video');
+  assert.deepEqual(
+    await relocateDataDir(source, destination, (msg) => logs.push(msg), false),
+    { copiedEntries: 2 },
+  );
   assert.equal(await readFile(join(destination, 'project-store-v1', 'projects.json'), 'utf8'), '[]');
-  assert.ok(existsSync(join(source, 'media', 'uploads', 'clip.mp4')), 'the source is kept intact');
+  assert.ok(existsSync(join(source, 'project-store-v1', 'projects.json')), 'the source is kept intact');
   assert.equal(existsSync(join(destination, 'export-cache.log')), false, 'regenerated files are not carried over');
-  assert.equal(await relocateDataDir(source, source, () => { throw new Error('no log expected'); }), 0);
+  assert.deepEqual(
+    await relocateDataDir(source, source, () => { throw new Error('no log expected'); }, false),
+    { copiedEntries: 0 },
+  );
+
+  // 5b. The SQLite store is the whole project store and cannot be copied file-wise while
+  // live: relocation refuses rather than producing a torn snapshot or an empty new root.
+  const sqliteLogs: string[] = [];
+  const sqliteTarget = join(fixture, 'sqlite-destination');
+  assert.deepEqual(
+    await relocateDataDir(source, sqliteTarget, (msg) => sqliteLogs.push(msg), true),
+    { refused: 'sqlite-store-active', copiedEntries: 0 },
+  );
+  assert.equal(existsSync(sqliteTarget), false, 'a refused relocation copies nothing at all');
+  assert.ok(sqliteLogs.some((msg) => msg.includes('refused')), 'the refusal is reported, never silent');
+
+  // 5c. The relocated upload directory is where the moved profile will resolve its
+  // writable uploads, so the caller can copy media into the right place.
+  assert.equal(relocatedUploadDir(destination), join(destination, 'media', 'uploads'));
 
   // 6. A second relocation into a populated destination overwrites nothing and says so.
   await writeFile(join(destination, 'deleted-projects-v1.json'), 'newer, must win');
-  const again = await relocateDataDir(source, destination, (msg) => logs.push(msg));
-  assert.equal(again, 0);
+  const again = await relocateDataDir(source, destination, (msg) => logs.push(msg), false);
+  assert.deepEqual(again, { copiedEntries: 0 });
   assert.equal(await readFile(join(destination, 'deleted-projects-v1.json'), 'utf8'), 'newer, must win');
-  assert.ok(logs.some((msg) => msg.includes('跳过已存在的')), 'a skipped entry is reported, never silent');
+  assert.ok(logs.some((msg) => msg.includes('skipped')), 'a skipped entry is reported, never silent');
 
   // 7. Creating the root up front is idempotent, so a first run never races a first write.
   const eager = join(fixture, 'eager', 'nested');

--- a/server/data-dir.verify.ts
+++ b/server/data-dir.verify.ts
@@ -122,6 +122,33 @@ try {
   // writable uploads, so the caller can copy media into the right place.
   assert.equal(relocatedUploadDir(destination), join(destination, 'media', 'uploads'));
 
+  // 5d. An interrupted relocation must never leave a half-copied entry looking complete.
+  // The copy stages aside and renames into place, so a leftover staging directory from a
+  // crashed attempt is discarded and the retry starts clean rather than adopting a partial
+  // store. Simulated here by planting the staging directory a crash would have left.
+  const resumed = join(fixture, 'resumed');
+  await mkdir(join(resumed, 'project-store-v1.incoming'), { recursive: true });
+  await writeFile(join(resumed, 'project-store-v1.incoming', 'half.json'), 'truncated');
+  assert.deepEqual(
+    await relocateDataDir(source, resumed, () => undefined, false),
+    { copiedEntries: 2 },
+  );
+  assert.equal(
+    await readFile(join(resumed, 'project-store-v1', 'projects.json'), 'utf8'),
+    '[]',
+    'the retry copies the real store, not the abandoned partial one',
+  );
+  assert.equal(
+    existsSync(join(resumed, 'project-store-v1', 'half.json')),
+    false,
+    'nothing from the crashed attempt survives into the adopted store',
+  );
+  assert.equal(
+    existsSync(join(resumed, 'project-store-v1.incoming')),
+    false,
+    'the staging directory is not left behind',
+  );
+
   // 6. A second relocation into a populated destination overwrites nothing and says so.
   await writeFile(join(destination, 'deleted-projects-v1.json'), 'newer, must win');
   const again = await relocateDataDir(source, destination, (msg) => logs.push(msg), false);

--- a/server/key-probes.ts
+++ b/server/key-probes.ts
@@ -9,6 +9,8 @@ import { environmentProxyUrl, proxyDispatcher } from './outbound-proxy.ts';
 import { getKey, KEY_NAMES, type KeyName } from './keystore.ts';
 import { r2Probe } from './r2.ts';
 import { mediaDirProbe, mediaDirPostCheck, mediaDirOkText } from './media-dir.ts';
+import { checkDataDir, readDataDirPointer } from './data-dir.ts';
+import { DATA_DIR_ENV, defaultRootDir, runtimeProfile } from './runtime-profile.ts';
 import {
   AI_SDK_BASE_URL_FORMAT,
   resolveLlmBaseUrl,
@@ -58,6 +60,23 @@ const PROXY_PROBE_URL = 'https://www.gstatic.com/generate_204';
 function proxyProbeUrl(overrides: Record<string, unknown>): string {
   if (Object.hasOwn(overrides, 'PROXY_URL')) return String(overrides.PROXY_URL ?? '').trim();
   return getKey('PROXY_URL').trim() || environmentProxyUrl();
+}
+
+/** Storage-root writability check: a local disk probe, never a network request. */
+export async function runDataDirProbe(overrides: Record<string, unknown>): Promise<ProbeResult> {
+  const profile = runtimeProfile();
+  if (process.env[DATA_DIR_ENV]?.trim()) {
+    return { ok: false, message: `目录由 ${DATA_DIR_ENV} 固定，无法在设置中修改` };
+  }
+  const raw = Object.hasOwn(overrides, DATA_DIR_ENV)
+    ? String(overrides[DATA_DIR_ENV] ?? '')
+    : readDataDirPointer() ?? '';
+  const started = Date.now();
+  const body = await checkDataDir(raw, defaultRootDir(profile));
+  const latencyMs = Date.now() - started;
+  return body.ok
+    ? { ok: true, latencyMs, message: body.note ?? '目录可写' }
+    : { ok: false, latencyMs, message: body.error ?? '目录检查失败' };
 }
 
 /** Test the saved proxy or the unsaved value currently shown in the settings field. */
@@ -423,6 +442,9 @@ export function makeGetter(overrides: Record<string, unknown>): Get {
 /** Run a connectivity probe of the provider's page. Unconfigured/unknown pages are returned before sending a request and do not hit the network.*/
 export async function runProbe(page: string, overrides: Record<string, unknown>): Promise<ProbeResult> {
   if (page === 'agent/proxy') return runProxyProbe(overrides);
+  // The storage root is not a keystore key (makeGetter would drop it), so its
+  // writability check reads the panel's raw value directly.
+  if (page === 'storage/projects') return runDataDirProbe(overrides);
   const probe = PROBES[page];
   if (!probe) return { ok: false, message: '该厂商暂不支持连接测试' };
   const get = makeGetter(overrides);

--- a/server/key-probes.verify.ts
+++ b/server/key-probes.verify.ts
@@ -1,8 +1,25 @@
 // checks:key-probes pure logic - detection table coverage, override whitelist, status classification,
 // MiniMax base_resp post-check, runProbe does not hit the network early exit. There are no real network requests in the whole process.
 import assert from 'node:assert/strict';
-import { PROBES, classifyStatus, makeGetter, minimaxPostCheck, networkMessage, runProbe, runProxyProbe } from './key-probes.ts';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { LLM_PROVIDER_PRESETS } from '../shared/llm-providers.ts';
+
+// Directory probes answer from the runtime profile, which resolves once at module load
+// out of HOME and the profile environment. Pin both to a throwaway home before importing
+// the module under test: otherwise a developer's own storage root, or an exported dev
+// profile id, decides the outcome of the directory assertions below.
+const fixtureHome = mkdtempSync(join(tmpdir(), 'openchatcut-key-probes-'));
+process.env.HOME = fixtureHome;
+process.env.USERPROFILE = fixtureHome;
+delete process.env.OPENCHATCUT_DEV_PROFILE_ID;
+delete process.env.OPENCHATCUT_DATA_DIR;
+process.on('exit', () => rmSync(fixtureHome, { recursive: true, force: true }));
+
+const {
+  PROBES, classifyStatus, makeGetter, minimaxPostCheck, networkMessage, runProbe, runProxyProbe,
+} = await import('./key-probes.ts');
 
 // 1. One-to-one correspondence with the provider page of settingsSchema (the page key has the same name); the llm page is derived from the preset,
 // Synchronize this list when adding other capability pages.
@@ -111,6 +128,45 @@ assert.match(networkMessage(Object.assign(new Error('The operation was aborted d
   assert.equal(relative.ok, false);
   assert.match(relative.message, /绝对路径/);
   assert.doesNotMatch(relative.message, /HTTP/);
+}
+
+// 9. Project storage root probe: a local disk check, never a network request. Empty = the
+// default root (legal), relative path rejected, writable folder accepted, and a root
+// pinned by the environment refuses the change instead of pretending to accept it.
+{
+  const unset = await runProbe('storage/projects', { OPENCHATCUT_DATA_DIR: '' });
+  assert.equal(unset.ok, true);
+  assert.match(unset.message, /默认目录 .*\.openchatcut/); // machine-dependent absolute path, anchor the tail only
+
+  const relative = await runProbe('storage/projects', { OPENCHATCUT_DATA_DIR: 'relative/saves' });
+  assert.equal(relative.ok, false);
+  assert.match(relative.message, /绝对路径/);
+  assert.doesNotMatch(relative.message, /HTTP/);
+
+  const target = join(fixtureHome, 'Saves');
+  const writable = await runProbe('storage/projects', { OPENCHATCUT_DATA_DIR: target });
+  assert.equal(writable.ok, true);
+  assert.match(writable.message, /目录可写/);
+
+  // Without the field in the payload, the probe tests the root already recorded by the
+  // settings UI, so "test connection" answers for the storage actually in use.
+  mkdirSync(join(fixtureHome, '.openchatcut'), { recursive: true });
+  writeFileSync(
+    join(fixtureHome, '.openchatcut', 'data-dir.json'),
+    JSON.stringify({ version: 1, dataDir: target }),
+  );
+  const recorded = await runProbe('storage/projects', {});
+  assert.equal(recorded.ok, true);
+  assert.match(recorded.message, new RegExp(`目录可写 · ${target}`));
+
+  process.env.OPENCHATCUT_DATA_DIR = target;
+  try {
+    const pinned = await runProbe('storage/projects', { OPENCHATCUT_DATA_DIR: join(fixtureHome, 'Elsewhere') });
+    assert.equal(pinned.ok, false);
+    assert.match(pinned.message, /固定/);
+  } finally {
+    delete process.env.OPENCHATCUT_DATA_DIR;
+  }
 }
 
 console.log('key-probes.verify OK');

--- a/server/plugins/settings.ts
+++ b/server/plugins/settings.ts
@@ -120,8 +120,13 @@ async function applyDataDirChange(
   const checked = await checkDataDir(raw, defaultRootDir(profile));
   if (!checked.ok) throw new Error(checked.error ?? 'invalid storage directory');
   const target = expandDataDir(raw);
-  if (target && target !== profile.rootDir) {
-    const outcome = await relocateDataDir(profile.rootDir, target, log, sqliteStoreEnabled());
+  // Clearing the field is a relocation too: it sends the next launch back to the
+  // default root, which is empty or stale for anyone who has been running
+  // elsewhere. Treating it as "no move" would skip both the SQLite refusal and
+  // the copy, and lose the projects exactly like the case this guards against.
+  const destination = target ?? defaultRootDir(profile);
+  if (destination !== profile.rootDir) {
+    const outcome = await relocateDataDir(profile.rootDir, destination, log, sqliteStoreEnabled());
     if (outcome.refused === 'sqlite-store-active') {
       throw new Error(
         'the project store has been migrated to SQLite and cannot be relocated yet: '
@@ -130,7 +135,7 @@ async function applyDataDirChange(
     }
     // Uploads are addressed by name through uploadReadDirs(), so the copy must
     // land where the relocated profile will resolve its writable upload dir.
-    await syncUploadDirectories(uploadDir(profile), relocatedUploadDir(target), log);
+    await syncUploadDirectories(uploadDir(profile), relocatedUploadDir(destination), log);
   }
   await writeDataDirPointer(target);
 }

--- a/server/plugins/settings.ts
+++ b/server/plugins/settings.ts
@@ -9,10 +9,19 @@ import {
   uploadDir,
 } from '../media-dir.ts';
 import {
+  DATA_DIR_ENV,
+  defaultRootDir,
   isIsolatedDevProfile,
   runtimeProfile,
   type RuntimeProfile,
 } from '../runtime-profile.ts';
+import {
+  checkDataDir,
+  expandDataDir,
+  readDataDirPointer,
+  relocateDataDir,
+  writeDataDirPointer,
+} from '../data-dir.ts';
 
 const ISOLATED_R2_SETTINGS = [
   'R2_ACCOUNT_ID',
@@ -70,8 +79,40 @@ function sendJson(res: ServerResponse, status: number, body: unknown): void {
 /** keyStatus + absolute path to the current asset directory. FCPXML export goes to /media/uploads/<name>
  * Convert to real disk path, otherwise every asset in NLE will be offline; the directory changes with MEDIA_DIR,
  * Only the server knows, so it is returned to the front-end along with the settings (non-key, can be disclosed). */
-function settingsBody() {
-  return { ...keyStatus(), mediaDir: uploadDir() };
+function settingsBody(restartRequired = false) {
+  const profile = runtimeProfile();
+  const status = keyStatus();
+  const configured = readDataDirPointer() ?? '';
+  return {
+    ...status,
+    // The storage root is configuration, not a credential: echo it raw so the
+    // settings field shows where projects actually live. It is not a keystore
+    // key (the keystore lives inside the root), hence the explicit merge.
+    models: { ...status.models, [DATA_DIR_ENV]: configured },
+    mediaDir: uploadDir(),
+    dataDir: profile.rootDir,
+    ...(restartRequired ? { restartRequired: true } : {}),
+  };
+}
+
+/** Apply a storage-root change: validate, copy the existing data, record the
+ *  pointer. The active profile resolved at startup, so the move only takes
+ *  effect on the next launch; the caller reports that to the user. */
+async function applyDataDirChange(
+  raw: string,
+  profile: RuntimeProfile,
+  log: (msg: string) => void,
+): Promise<void> {
+  if (process.env[DATA_DIR_ENV]?.trim()) {
+    throw new Error(`storage directory is pinned by ${DATA_DIR_ENV} and cannot be changed from settings`);
+  }
+  const checked = await checkDataDir(raw, defaultRootDir(profile));
+  if (!checked.ok) throw new Error(checked.error ?? 'invalid storage directory');
+  const target = expandDataDir(raw);
+  if (target && target !== profile.rootDir) {
+    await relocateDataDir(profile.rootDir, target, log);
+  }
+  await writeDataDirPointer(target);
 }
 
 export function settingsPlugin(): Plugin {
@@ -96,6 +137,18 @@ export function settingsPlugin(): Plugin {
             const profile = runtimeProfile();
             const patch = await readBody(req);
             assertProfileSensitiveSettingsPatch(patch, profile);
+            // The storage root is not a keystore key (the keystore lives inside
+            // it): handle and strip it before setKeys sees the patch.
+            let dataDirChanged = false;
+            if (Object.hasOwn(patch, DATA_DIR_ENV)) {
+              await applyDataDirChange(
+                String(patch[DATA_DIR_ENV] ?? ''),
+                profile,
+                (msg) => server.config.logger.info(msg),
+              );
+              delete patch[DATA_DIR_ENV];
+              dataDirChanged = true;
+            }
             const previousMediaDir = uploadDir(profile);
             if ('MEDIA_DIR' in patch) {
               const rawMediaDir = String(patch.MEDIA_DIR ?? '');
@@ -109,7 +162,7 @@ export function settingsPlugin(): Plugin {
               );
             }
             await setKeys(patch);
-            sendJson(res, 200, settingsBody());
+            sendJson(res, 200, settingsBody(dataDirChanged));
             return;
           }
           sendJson(res, 405, { error: 'method not allowed — use GET or POST' });

--- a/server/plugins/settings.ts
+++ b/server/plugins/settings.ts
@@ -20,8 +20,10 @@ import {
   expandDataDir,
   readDataDirPointer,
   relocateDataDir,
+  relocatedUploadDir,
   writeDataDirPointer,
 } from '../data-dir.ts';
+import { sqliteStoreEnabled } from '../storage/sqlite-store.ts';
 
 const ISOLATED_R2_SETTINGS = [
   'R2_ACCOUNT_ID',
@@ -97,7 +99,13 @@ function settingsBody(restartRequired = false) {
 
 /** Apply a storage-root change: validate, copy the existing data, record the
  *  pointer. The active profile resolved at startup, so the move only takes
- *  effect on the next launch; the caller reports that to the user. */
+ *  effect on the next launch; the caller reports that to the user.
+ *
+ *  Media is copied separately from the RESOLVED upload directory, not from
+ *  `<root>/media`: in the default profile uploads live outside the root (the
+ *  checkout's `public/media/uploads`, or `userData/...` when packaged), so
+ *  copying the root's own `media` folder would move an empty directory and
+ *  take every `/media/uploads/...` reference offline after the restart. */
 async function applyDataDirChange(
   raw: string,
   profile: RuntimeProfile,
@@ -106,11 +114,23 @@ async function applyDataDirChange(
   if (process.env[DATA_DIR_ENV]?.trim()) {
     throw new Error(`storage directory is pinned by ${DATA_DIR_ENV} and cannot be changed from settings`);
   }
+  if (isIsolatedDevProfile(profile)) {
+    throw new Error('storage directory cannot be changed while an isolated development profile is active');
+  }
   const checked = await checkDataDir(raw, defaultRootDir(profile));
   if (!checked.ok) throw new Error(checked.error ?? 'invalid storage directory');
   const target = expandDataDir(raw);
   if (target && target !== profile.rootDir) {
-    await relocateDataDir(profile.rootDir, target, log);
+    const outcome = await relocateDataDir(profile.rootDir, target, log, sqliteStoreEnabled());
+    if (outcome.refused === 'sqlite-store-active') {
+      throw new Error(
+        'the project store has been migrated to SQLite and cannot be relocated yet: '
+        + 'moving a live database needs a quiesced snapshot, which this setting does not do',
+      );
+    }
+    // Uploads are addressed by name through uploadReadDirs(), so the copy must
+    // land where the relocated profile will resolve its writable upload dir.
+    await syncUploadDirectories(uploadDir(profile), relocatedUploadDir(target), log);
   }
   await writeDataDirPointer(target);
 }

--- a/server/runtime-profile.ts
+++ b/server/runtime-profile.ts
@@ -1,7 +1,9 @@
 import { homedir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, resolve } from 'node:path';
+import { readDataDirPointer } from './data-dir.ts';
 
 export const DEV_PROFILE_ID_ENV = 'OPENCHATCUT_DEV_PROFILE_ID';
+export const DATA_DIR_ENV = 'OPENCHATCUT_DATA_DIR';
 const DEV_PROFILE_ENV_PREFIX = 'OPENCHATCUT_DEV_PROFILE_';
 const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
@@ -91,15 +93,33 @@ function configuredProfileId(env: RuntimeProfileEnv): string | null {
   return value;
 }
 
+/** User-chosen storage root (games-style save folder): data survives app removal.
+ *  The environment variable wins so a launch script can pin a location; the
+ *  settings UI records its choice in the fixed pointer file instead.
+ *  Accepts ~/ expansion, requires an absolute path, and rejects anything else
+ *  loudly so a typo never silently falls back to the hidden default location. */
+function configuredDataDir(env: RuntimeProfileEnv, home: string): string | null {
+  const raw = env[DATA_DIR_ENV]?.trim();
+  if (!raw) return readDataDirPointer(home);
+  const expanded = raw === '~' ? home : raw.replace(/^~(?=\/)/, home);
+  if (!isAbsolute(expanded)) {
+    throw new Error(`${DATA_DIR_ENV} must be an absolute path (got: ${raw})`);
+  }
+  return resolve(expanded);
+}
+
 export function resolveRuntimeProfile(
   env: RuntimeProfileEnv = process.env,
   locations: RuntimeProfileLocations = {},
 ): RuntimeProfile {
   const home = locations.homeDir ?? homedir();
   const cwd = locations.cwd ?? process.cwd();
+  const dataDir = configuredDataDir(env, home);
   const profileId = configuredProfileId(env);
   if (profileId) {
-    const rootDir = join(home, '.openchatcut', 'dev-profiles', profileId);
+    // An explicit data dir replaces the per-checkout hidden profile root: the
+    // user asked for their projects to live at a visible, durable location.
+    const rootDir = dataDir ?? join(home, '.openchatcut', 'dev-profiles', profileId);
     const base = profileBase(
       rootDir,
       join(rootDir, 'media', 'uploads'),
@@ -108,12 +128,14 @@ export function resolveRuntimeProfile(
     );
     return Object.freeze({ mode: 'isolated-dev', id: profileId, ...base });
   }
-  const rootDir = join(home, '.openchatcut');
+  const rootDir = dataDir ?? join(home, '.openchatcut');
   const authOverride = env.OPENCHATCUT_PROJECT_STORE_AUTH_DIR?.trim();
   const generationOverride = env.OPENCHATCUT_GENERATION_JOB_STORE;
   const base = profileBase(
     rootDir,
-    join(cwd, 'public', 'media', 'uploads'),
+    // With a user-chosen data dir, media belongs next to the projects it
+    // backs; the checkout-relative default only applies to the hidden root.
+    dataDir ? join(dataDir, 'media', 'uploads') : join(cwd, 'public', 'media', 'uploads'),
     generationOverride ?? join(rootDir, 'generation-operations-v1.json'),
     resolve(cwd, '.env.local'),
   );
@@ -135,4 +157,15 @@ export function isIsolatedDevProfile(
   profile: RuntimeProfile = activeProfile,
 ): profile is IsolatedDevRuntimeProfile {
   return profile.mode === 'isolated-dev';
+}
+
+/** Storage root the app would use with no data directory configured. Lets the
+ *  settings UI say where clearing the field actually leads. */
+export function defaultRootDir(
+  profile: RuntimeProfile = activeProfile,
+  home: string = homedir(),
+): string {
+  return isIsolatedDevProfile(profile)
+    ? join(home, '.openchatcut', 'dev-profiles', profile.id)
+    : join(home, '.openchatcut');
 }

--- a/server/runtime-profile.ts
+++ b/server/runtime-profile.ts
@@ -94,13 +94,25 @@ function configuredProfileId(env: RuntimeProfileEnv): string | null {
 }
 
 /** User-chosen storage root (games-style save folder): data survives app removal.
- *  The environment variable wins so a launch script can pin a location; the
- *  settings UI records its choice in the fixed pointer file instead.
+ *
+ *  Resolution order, and why:
+ *  1. The environment variable, so a launch script can pin a location. It is
+ *     explicit per process, so it is also the only form an isolated dev profile
+ *     accepts.
+ *  2. The pointer file written by the settings UI, for the ordinary profile ONLY.
+ *     An isolated dev profile must never be redirected by the developer's own
+ *     machine-wide setting: that would break the isolation guarantee and let a
+ *     checkout write into the real storage root.
+ *
  *  Accepts ~/ expansion, requires an absolute path, and rejects anything else
  *  loudly so a typo never silently falls back to the hidden default location. */
-function configuredDataDir(env: RuntimeProfileEnv, home: string): string | null {
+function configuredDataDir(
+  env: RuntimeProfileEnv,
+  home: string,
+  isolated: boolean,
+): string | null {
   const raw = env[DATA_DIR_ENV]?.trim();
-  if (!raw) return readDataDirPointer(home);
+  if (!raw) return isolated ? null : readDataDirPointer(home);
   const expanded = raw === '~' ? home : raw.replace(/^~(?=\/)/, home);
   if (!isAbsolute(expanded)) {
     throw new Error(`${DATA_DIR_ENV} must be an absolute path (got: ${raw})`);
@@ -114,11 +126,12 @@ export function resolveRuntimeProfile(
 ): RuntimeProfile {
   const home = locations.homeDir ?? homedir();
   const cwd = locations.cwd ?? process.cwd();
-  const dataDir = configuredDataDir(env, home);
   const profileId = configuredProfileId(env);
+  const dataDir = configuredDataDir(env, home, profileId !== null);
   if (profileId) {
-    // An explicit data dir replaces the per-checkout hidden profile root: the
-    // user asked for their projects to live at a visible, durable location.
+    // Only an explicit OPENCHATCUT_DATA_DIR reaches here (the pointer file is
+    // ignored for isolated profiles), so redirecting this checkout's root is a
+    // deliberate per-run choice, never a leak from the machine-wide setting.
     const rootDir = dataDir ?? join(home, '.openchatcut', 'dev-profiles', profileId);
     const base = profileBase(
       rootDir,

--- a/server/runtime-profile.verify.ts
+++ b/server/runtime-profile.verify.ts
@@ -150,8 +150,8 @@ try {
     join(dataDirHome, '.openchatcut'),
   );
 
-  // An isolated dev profile keeps its own keystore, but its data moves too: the user
-  // asked for a visible, durable location, which outranks the per-checkout root.
+  // An isolated dev profile accepts an EXPLICIT data dir: that is a deliberate
+  // per-run choice by whoever launched the checkout.
   const isolatedData = resolveRuntimeProfile({
     [DEV_PROFILE_ID_ENV]: profileAId,
     [DATA_DIR_ENV]: chosen,
@@ -160,6 +160,21 @@ try {
   assert.equal(isolatedData.rootDir, chosen);
   assert.equal(isolatedData.mediaDir, join(chosen, 'media', 'uploads'));
   assert.equal(isolatedData.keystorePath, join(chosen, 'settings.env'));
+
+  // ...but it must NEVER be redirected by the machine-wide pointer file. Isolation is a
+  // hard rule: a checkout would otherwise read and write the developer's real storage
+  // root just because they once set a folder in the settings UI.
+  writeFileSync(dataDirPointerPath(dataDirHome), JSON.stringify({ version: 1, dataDir: pointed }));
+  const isolatedPointer = resolveRuntimeProfile(
+    { [DEV_PROFILE_ID_ENV]: profileAId },
+    { homeDir: dataDirHome, cwd },
+  );
+  assert.equal(
+    isolatedPointer.rootDir,
+    join(dataDirHome, '.openchatcut', 'dev-profiles', profileAId),
+    'an isolated profile ignores the machine-wide pointer file',
+  );
+  assert.equal(isolatedPointer.mediaDir, join(isolatedPointer.rootDir, 'media', 'uploads'));
 
   // defaultRootDir answers "where does clearing the field lead?", so it must ignore
   // the configured root in both modes.

--- a/server/runtime-profile.verify.ts
+++ b/server/runtime-profile.verify.ts
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { DEV_PROFILE_ID_ENV, resolveRuntimeProfile } from './runtime-profile.ts';
+import { DATA_DIR_ENV, DEV_PROFILE_ID_ENV, defaultRootDir, resolveRuntimeProfile } from './runtime-profile.ts';
+import { dataDirPointerPath } from './data-dir.ts';
 import { projectStoreAuthDir } from './project-store-http-auth.ts';
 
 const homeDir = resolve('runtime-profile-fixtures', 'home');
@@ -90,3 +93,81 @@ assert.throws(
   () => resolveRuntimeProfile({ OPENCHATCUT_DEV_PROFILE_ROOT: isolatedRoot }, { homeDir, cwd }),
   /Unsupported isolated development profile variable/,
 );
+
+// ── User-chosen storage root ─────────────────────────────────────────────────
+// The whole point of the setting is that projects survive removing the app, so the
+// chosen root must win over every default: the hidden global root, the per-checkout
+// media folder, and the isolated dev profile root.
+const dataDirHome = mkdtempSync(join(tmpdir(), 'openchatcut-runtime-data-dir-'));
+try {
+  const chosen = join(dataDirHome, 'Saves', 'OpenChatCut');
+  const envDataDir = resolveRuntimeProfile({ [DATA_DIR_ENV]: chosen }, { homeDir: dataDirHome, cwd });
+  assert.equal(envDataDir.mode, 'default');
+  assert.equal(envDataDir.rootDir, chosen);
+  assert.equal(envDataDir.authDir, join(chosen, 'project-store-auth-v1'));
+  assert.equal(envDataDir.generationJobStore, join(chosen, 'generation-operations-v1.json'));
+  assert.equal(envDataDir.projectStore.directory, join(chosen, 'project-store-v1'));
+  assert.equal(envDataDir.projectStore.tombstonePath, join(chosen, 'deleted-projects-v1.json'));
+  // Media follows the projects it backs, instead of staying in the checkout.
+  assert.equal(envDataDir.mediaDir, join(chosen, 'media', 'uploads'));
+  // The keystore stays with the checkout in default mode: it is not project data.
+  assert.equal(envDataDir.keystorePath, resolve(cwd, '.env.local'));
+
+  // `~/` expands, whitespace is trimmed, and a blank value is the same as no value.
+  assert.equal(
+    resolveRuntimeProfile({ [DATA_DIR_ENV]: '  ~/Saves  ' }, { homeDir: dataDirHome, cwd }).rootDir,
+    join(dataDirHome, 'Saves'),
+  );
+  assert.equal(
+    resolveRuntimeProfile({ [DATA_DIR_ENV]: '~' }, { homeDir: dataDirHome, cwd }).rootDir,
+    dataDirHome,
+  );
+  assert.equal(
+    resolveRuntimeProfile({ [DATA_DIR_ENV]: '   ' }, { homeDir: dataDirHome, cwd }).rootDir,
+    join(dataDirHome, '.openchatcut'),
+  );
+  // A typo must fail loudly: silently falling back would hide the projects somewhere
+  // the user never chose, which is exactly what this setting exists to prevent.
+  assert.throws(
+    () => resolveRuntimeProfile({ [DATA_DIR_ENV]: 'relative/saves' }, { homeDir: dataDirHome, cwd }),
+    /must be an absolute path/,
+  );
+
+  // With no environment variable, the pointer file recorded by the settings UI is used,
+  // and the environment variable wins over it when both are present.
+  const pointed = join(dataDirHome, 'Pointed');
+  mkdirSync(join(dataDirHome, '.openchatcut'), { recursive: true });
+  writeFileSync(dataDirPointerPath(dataDirHome), JSON.stringify({ version: 1, dataDir: pointed }));
+  assert.equal(resolveRuntimeProfile({}, { homeDir: dataDirHome, cwd }).rootDir, pointed);
+  assert.equal(
+    resolveRuntimeProfile({ [DATA_DIR_ENV]: chosen }, { homeDir: dataDirHome, cwd }).rootDir,
+    chosen,
+  );
+  // A damaged pointer degrades to the default root rather than blocking startup.
+  writeFileSync(dataDirPointerPath(dataDirHome), 'not json at all');
+  assert.equal(
+    resolveRuntimeProfile({}, { homeDir: dataDirHome, cwd }).rootDir,
+    join(dataDirHome, '.openchatcut'),
+  );
+
+  // An isolated dev profile keeps its own keystore, but its data moves too: the user
+  // asked for a visible, durable location, which outranks the per-checkout root.
+  const isolatedData = resolveRuntimeProfile({
+    [DEV_PROFILE_ID_ENV]: profileAId,
+    [DATA_DIR_ENV]: chosen,
+  }, { homeDir: dataDirHome, cwd });
+  assert.equal(isolatedData.mode, 'isolated-dev');
+  assert.equal(isolatedData.rootDir, chosen);
+  assert.equal(isolatedData.mediaDir, join(chosen, 'media', 'uploads'));
+  assert.equal(isolatedData.keystorePath, join(chosen, 'settings.env'));
+
+  // defaultRootDir answers "where does clearing the field lead?", so it must ignore
+  // the configured root in both modes.
+  assert.equal(defaultRootDir(envDataDir, dataDirHome), join(dataDirHome, '.openchatcut'));
+  assert.equal(
+    defaultRootDir(isolatedData, dataDirHome),
+    join(dataDirHome, '.openchatcut', 'dev-profiles', profileAId),
+  );
+} finally {
+  rmSync(dataDirHome, { recursive: true, force: true });
+}

--- a/src/components/settings/SettingsDialog.tsx
+++ b/src/components/settings/SettingsDialog.tsx
@@ -112,7 +112,9 @@ function useSaveKeys(values: Values, onSaved: (next: KeyStatusResponse) => void)
       const body = await res.json().catch(() => ({})) as Partial<KeyStatusResponse> & { error?: string };
       if (!res.ok) throw new Error(body.error || t('保存失败 ({n})', { n: res.status }));
       onSaved(body as KeyStatusResponse);
-      setMsg(savedMessage());
+      // A storage-folder change is copied immediately but only used on the next
+      // launch, so saying "saved" alone would look like nothing happened.
+      setMsg(body.restartRequired ? t('已保存 · 重启应用后新的工程存储目录才会生效') : savedMessage());
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {

--- a/src/components/settings/settingsFields.ts
+++ b/src/components/settings/settingsFields.ts
@@ -48,6 +48,9 @@ export interface KeyStatusResponse {
   keys: Record<string, KeyState>;
   caps: Record<string, boolean>;
   models: Record<string, string>;
+  /** Set by the save response when the change only lands on the next launch
+   *  (project storage folder: the runtime profile resolves at startup). */
+  restartRequired?: boolean;
 }
 export const secret = (name: string, label: string): SettingsField => ({ name, label, kind: 'secret' });
 export const text = (

--- a/src/components/settings/settingsSchema.ts
+++ b/src/components/settings/settingsSchema.ts
@@ -262,8 +262,16 @@ export const SETTINGS_CATEGORIES: readonly SettingsCategory[] = [
   {
     key: 'cloud', title: '存储', icon: 'cloud',
     groups: [
-      { key: 'storage', title: '媒体存储', hint: '素材的本地保存目录，与可选的 R2 云备份。',
+      { key: 'storage', title: '媒体存储', hint: '工程与素材的本地保存目录，与可选的 R2 云备份。',
         vendors: [
+          { key: 'storage/projects', vendor: 'localdisk', title: '工程存储目录',
+            note: '工程、历史版本与素材的存放位置。默认放在应用数据目录里；'
+              + '改到你自己的目录（外置硬盘、同步盘）后，卸载或重装应用都不会动到作品。'
+              + '保存时会把现有数据复制到新目录（原目录保留不删），重启应用后生效。',
+            fields: [
+              directory('OPENCHATCUT_DATA_DIR', '工程存储目录', '应用默认数据目录',
+                '桌面端点击“选择目录”；也可手动输入绝对路径（可用 ~/ 开头）。清除后回到默认目录。'),
+            ] },
           { key: 'storage/local', vendor: 'localdisk', title: '本地磁盘',
             note: '桌面端默认把素材存入系统应用数据目录，浏览器开发版默认使用 public/media/uploads/。'
               + '可选择任意本机目录或外置硬盘；保存后旧目录中的素材会复制到新目录（原文件保留），'

--- a/src/i18n/dict/en/settings.ts
+++ b/src/i18n/dict/en/settings.ts
@@ -482,4 +482,10 @@ export default {
   '确认清理': 'Confirm cleanup',
   '清理中…': 'Cleaning up…',
   '已清理 {removed} 个旧 JSON 文件': 'Removed {removed} old JSON files',
+  '工程存储目录': 'Project storage folder',
+  '应用默认数据目录': 'Default app data folder',
+  '工程与素材的本地保存目录，与可选的 R2 云备份。': 'Where projects and media are stored locally, plus optional R2 cloud backup.',
+  '工程、历史版本与素材的存放位置。默认放在应用数据目录里；改到你自己的目录（外置硬盘、同步盘）后，卸载或重装应用都不会动到作品。保存时会把现有数据复制到新目录（原目录保留不删），重启应用后生效。': 'Where projects, version history and media are kept. Defaults to the app data folder; point it at a folder of your own (external drive, synced folder) and uninstalling or reinstalling the app never touches your work. Saving copies the existing data to the new folder (the old one is kept, not deleted); takes effect after a restart.',
+  '桌面端点击“选择目录”；也可手动输入绝对路径（可用 ~/ 开头）。清除后回到默认目录。': 'On desktop, click "Choose folder"; you can also type an absolute path (~/ accepted). Clear it to return to the default folder.',
+  '已保存 · 重启应用后新的工程存储目录才会生效': 'Saved · the new project storage folder takes effect after a restart',
 } as Record<string, string>;


### PR DESCRIPTION
## Why

Projects, version history and media live in a hidden application data directory. Uninstalling or reinstalling the app sits on top of the user's work, and a user who wants that work on an external drive or a synced folder has no way to say so. This adds a *project storage folder* setting, next to the media directory one that already exists.

I hit this while using OpenChatCut for real editing work: I wanted the saved projects in my own backed-up folder, not under `~/.openchatcut`.

## How it resolves

| Source | Behaviour |
|---|---|
| `OPENCHATCUT_DATA_DIR` | pins the root from a launch script, and the settings panel refuses to change it |
| `~/.openchatcut/data-dir.json` | pointer file written by the settings panel |
| neither | today's behaviour, unchanged |

The chosen path cannot be stored in the settings keystore: an isolated dev profile keeps its keystore *inside* the storage root, so reading it would mean already knowing the root. Hence the small pointer file at a fixed location that never moves. A damaged pointer degrades to the default rather than blocking startup, because the profile resolves synchronously at module load and has nowhere to report an error.

## Relocation safety

Saving copies the known store entries (`project-store-v1`, `media`, tombstones, generation operations) into the new root and **never deletes the source**: relocating must not be the step that loses someone's projects. An entry that already exists in a non-empty destination is skipped and logged, never overwritten. Regenerated files (logs, caches) stay behind.

The active profile is resolved at startup, so the move only applies on the next launch. The save response reports that with `restartRequired`, and the panel says so instead of the generic "saved" message.

## Test suite hardening included

`server/key-probes.verify.ts` was not hermetic. Its local-directory assertions read the runtime profile, which resolves once at module load out of `HOME` and the profile environment, so a developer's own storage root, or an exported `OPENCHATCUT_DEV_PROFILE_ID`, could decide their outcome. Assertion 8 failed for me on a path outside the checkout. The suite now pins `HOME` and the profile environment to a throwaway directory before importing the module under test, so the existing assertions keep their meaning on any machine.

## Verification

- `server/data-dir.verify.ts` (new): path expansion, pointer round trip and its degradation, writability probe, relocation safety, idempotent root creation. Registered in `verify:runtime-profile`.
- `server/runtime-profile.verify.ts`: environment variable wins over the pointer, `~/` expansion, relative path throws, damaged pointer degrades, isolated dev profile follows the chosen root, `defaultRootDir()` still answers "where does clearing the field lead?".
- `server/key-probes.verify.ts`: new `storage/projects` probe block (unset, relative, writable, recorded pointer, pinned by environment). Local disk only, no network request.
- `tsc -b`, `oxlint`, `verify:i18n`, `verify:runtime-profile`, `verify:affected`: all pass. The three suites above also pass with a hostile environment exported (`OPENCHATCUT_DEV_PROFILE_ID` + `OPENCHATCUT_DATA_DIR` set to unrelated values).

Happy to split the `key-probes.verify.ts` isolation into its own PR if you would rather review it separately.