### PR TITLE
fix(verify): redirect USERPROFILE too so project-store.verify works on Windows

### DIFF
--- a/server/plugins/project-store.verify.ts
+++ b/server/plugins/project-store.verify.ts
@@ -44,15 +44,19 @@ async function verifyAtomicWriteOrdering(): Promise<void> {
 }
 
 async function verifyCorruptEntryIsolation(root: string): Promise<void> {
-  const previousHome = process.env.HOME;
+  // os.homedir() resolves from USERPROFILE on Windows and HOME elsewhere, and
+  // runtime-profile routes the store through it; redirect both so the test root
+  // is honored on every platform.
+  const previous = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE };
   process.env.HOME = root;
+  process.env.USERPROFILE = root;
   try {
     const storeDir = join(root, '.openchatcut', 'project-store-v1');
     await mkdir(storeDir, { recursive: true });
     await writeFile(join(storeDir, '.ready'), '1\n');
     await writeFile(join(storeDir, `${encodeURIComponent('project:healthy')}.json`), JSON.stringify({ healthy: true }));
     await writeFile(join(storeDir, `${encodeURIComponent('project:broken')}.json`), '{');
-    // Dynamic import is intentional: project-store captures HOME at module evaluation.
+    // Dynamic import is intentional: project-store captures the resolved store root at module evaluation.
     const { readStore } = await import('./project-store.ts');
     const store = await readStore();
     assert.deepEqual(store.entries['project:healthy'], { healthy: true });
@@ -66,8 +70,10 @@ async function verifyCorruptEntryIsolation(root: string): Promise<void> {
     const quarantine = await readdir(join(storeDir, '.quarantine'));
     assert.equal(quarantine.length, 1);
   } finally {
-    if (previousHome === undefined) delete process.env.HOME;
-    else process.env.HOME = previousHome;
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`verifyCorruptEntryIsolation` in `server/plugins/project-store.verify.ts` redirects the store root by setting only `process.env.HOME`. On Windows, `os.homedir()` (used by `server/runtime-profile.ts` → `server/plugins/project-store.ts`) resolves from **USERPROFILE** and ignores `HOME`, so the check reads the developer's real profile instead of the temp root and fails at the first assertion:

```
AssertionError: Expected values to be strictly deep-equal:
+ actual - expected
+ undefined
- { healthy: true }
```

## Fix

Redirect and restore both `HOME` and `USERPROFILE` around the check, so the test root is honored on every platform (setting `USERPROFILE` is inert on POSIX).

## Verification

- `npx tsx server/plugins/project-store.verify.ts` × 5 on Windows (Node 24.15.0): all pass (previously 5/5 fail)
- `npx tsc --noEmit`: clean

修复 Windows 上 `project-store.verify` 因只重定向 `HOME` 而 `os.homedir()` 读 `USERPROFILE` 导致的失败;同时重定向并恢复两个变量。