### PR TITLE
feat: marking mode — playhead follows the audible media clock while playing

### DIFF
--- a/src/components/timeline/usePlayheadPaint.ts
+++ b/src/components/timeline/usePlayheadPaint.ts
@@ -6,6 +6,17 @@ import type { CallbackListener, PlayerRef } from '@remotion/player';
 import { loadTimelineView, saveTimelineView } from '../../persist/sessionPrefs';
 import { HEADER_W, fmt, fmtClock } from './timelineUtil';
 
+export interface AudibleAudioItem {
+  /** Timeline start frame of the audio item. */
+  startFrame: number;
+  /** Item playback rate (timeline frames per source frame). */
+  playbackRate: number;
+  /** Source in-point in source-media frames (srcInFrame ?? 0). */
+  srcInFrame: number;
+  /** Media URL of the item, used to pick the matching media element. */
+  src: string;
+}
+
 interface PlayheadDeps {
   playerRef: RefObject<PlayerRef | null>;
   projectId?: string;
@@ -13,6 +24,47 @@ interface PlayheadDeps {
   fps: number;
   total: number;
   px: number;
+  /**
+   * Marking mode: returns the audio item audible at the given playhead frame,
+   * or null when the playhead should keep following the Player's frame clock.
+   * When an item is returned while playing, the playhead (and therefore the
+   * markers placed at it) follows the audible media element's own clock — what
+   * you actually hear — instead of the wall-clock frame. This eliminates the
+   * drift between playhead and audio caused by main-thread stalls (e.g. rapid
+   * marker creation), which Remotion only re-syncs beyond ~0.1–0.45s of drift.
+   */
+  getAudibleItem?: (playheadFrame: number) => AudibleAudioItem | null;
+}
+
+/**
+ * Map a media element's currentTime (source seconds) to a timeline frame for
+ * an audio item. Pure so it can be unit-verified.
+ */
+export function audioMediaTimeToTimelineFrame(
+  mediaSeconds: number,
+  item: AudibleAudioItem,
+  fps: number,
+): number {
+  const sourceFrame = mediaSeconds * fps;
+  return item.startFrame + (sourceFrame - item.srcInFrame) / item.playbackRate;
+}
+
+// Constant WebAudio output latency shifts what you HEAR vs element.currentTime.
+// Measure once (lazily) and subtract, so markers land on the audible beat
+// instead of a few frames early. Falls back to 0 when the platform does not
+// expose a usable latency (Windows frequently reports 0).
+let measuredAudioLatency: number | null = null;
+function audioOutputLatencySeconds(): number {
+  if (measuredAudioLatency !== null) return measuredAudioLatency;
+  try {
+    const ctx = new AudioContext();
+    const latency = (ctx.baseLatency ?? 0) + (ctx.outputLatency ?? 0);
+    void ctx.close();
+    measuredAudioLatency = Math.min(Math.max(latency, 0), 0.3);
+  } catch {
+    measuredAudioLatency = 0;
+  }
+  return measuredAudioLatency;
 }
 
 interface MediaMetadataSyncPlayer {
@@ -50,13 +102,17 @@ export function attachPlayheadMediaSync(
   };
 }
 
-export function usePlayheadPaint({ playerRef, projectId, timelineId, fps, total, px }: PlayheadDeps) {
+export function usePlayheadPaint({ playerRef, projectId, timelineId, fps, total, px, getAudibleItem }: PlayheadDeps) {
   const projectIdRef = useRef(projectId);
   projectIdRef.current = projectId;
   const timelineIdRef = useRef(timelineId);
   timelineIdRef.current = timelineId;
   const totalRef = useRef(total);
   totalRef.current = total;
+  const fpsRef = useRef(fps);
+  fpsRef.current = fps;
+  const getAudibleItemRef = useRef(getAudibleItem);
+  getAudibleItemRef.current = getAudibleItem;
   // Restore once per project + timeline pair. A missing record deliberately seeks
   // to frame 0 instead of inheriting the Player's stale frame from another tab.
   const restoredForRef = useRef<string | null>(null);
@@ -68,6 +124,25 @@ export function usePlayheadPaint({ playerRef, projectId, timelineId, fps, total,
   const rulerTimecodeRef = useRef<HTMLSpanElement | null>(null);
   const timecodePreviewFrameRef = useRef<number | null>(null);
   const [playing, setPlaying] = useState(false);
+  // Marking mode: last playhead frame derived from the audible media element's
+  // own clock. Non-null while the audio clock owns the playhead; the Player's
+  // frameupdate then only feeds the fallback/resume reference.
+  const lastAudioFrameRef = useRef<number | null>(null);
+  const lastAudioHeadSaveRef = useRef(0);
+  const findAudibleMediaElement = (item: AudibleAudioItem | null): HTMLMediaElement | null => {
+    const player = playerRef.current;
+    const container = (player as unknown as { getContainerNode?: () => EventTarget | null })?.getContainerNode?.();
+    if (!container || !(container instanceof HTMLElement)) return null;
+    const media = Array.from(container.querySelectorAll<HTMLMediaElement>('audio,video'));
+    if (!media.length) return null;
+    // Prefer the element matching the audible item's src; fall back to the
+    // first element that is actually playing.
+    if (item) {
+      const match = media.find((el) => (el.currentSrc || el.src).includes(item.src));
+      if (match) return match;
+    }
+    return media.find((el) => !el.paused && el.readyState >= 2) ?? null;
+  };
   // coalesce frameupdate → one paint per animation frame (smoother playhead)
   const pendingFrameRef = useRef<number | null>(null);
   const paintRafRef = useRef(0);
@@ -140,6 +215,9 @@ export function usePlayheadPaint({ playerRef, projectId, timelineId, fps, total,
       // The stream is throttled and saved once (~800ms), and it can be resumed after refresh wherever it is paused/draged.
       let lastHeadSave = 0;
       const onFrame = (event: { detail: { frame: number } }) => {
+        // Marking mode: while the audible media clock owns the playhead, the
+        // wall-clock frame must not overwrite it (markers read playheadRef).
+        if (lastAudioFrameRef.current !== null) return;
         playheadRef.current = Math.max(0, event.detail.frame);
         pendingFrameRef.current = event.detail.frame;
         if (!paintRafRef.current) paintRafRef.current = requestAnimationFrame(flush);
@@ -157,7 +235,9 @@ export function usePlayheadPaint({ playerRef, projectId, timelineId, fps, total,
       const onPlay = () => setPlaying(true);
       const onPause = () => {
         setPlaying(false);
-        const f = player.getCurrentFrame();
+        // Prefer the last audio-clock frame when marking mode was active, so
+        // pausing does not snap the playhead forward to the wall-clock frame.
+        const f = lastAudioFrameRef.current ?? player.getCurrentFrame();
         paintPlayheadRef.current(f, true);
         persistHead(f);
       };
@@ -201,6 +281,46 @@ export function usePlayheadPaint({ playerRef, projectId, timelineId, fps, total,
     const watchdog = setInterval(tick, 100);
     return () => { clearInterval(watchdog); detach?.(); };
   }, [playerRef]);
+  // Marking mode audio lock: while playing and an audible audio item exists,
+  // drive the playhead from the media element's own clock (what is actually
+  // heard) so marker placement stays locked to the sound even when the main
+  // thread stalls. The Remotion Player advances frames by wall-clock time;
+  // audio advances on its own hardware clock, and Remotion only re-syncs them
+  // beyond ~0.1–0.45s of drift — which is exactly the audible "playhead runs
+  // ahead of the beat" symptom during high-frequency marking.
+  useEffect(() => {
+    if (!playing || !getAudibleItem) return undefined;
+    lastAudioFrameRef.current = null;
+    let raf = 0;
+    const latency = audioOutputLatencySeconds();
+    const loop = () => {
+      const item = getAudibleItemRef.current?.(playheadRef.current) ?? null;
+      const el = findAudibleMediaElement(item);
+      if (el && item && el.currentTime > 0 && !el.paused) {
+        const mediaSec = Math.max(0, el.currentTime - latency);
+        const raw = audioMediaTimeToTimelineFrame(mediaSec, item, fpsRef.current);
+        const clamped = Math.max(0, Math.min(Math.max(0, totalRef.current - 1), Math.round(raw)));
+        lastAudioFrameRef.current = clamped;
+        paintPlayheadRef.current(clamped);
+        const now = performance.now();
+        if (clamped > 0 && now - lastAudioHeadSaveRef.current > 800) {
+          lastAudioHeadSaveRef.current = now;
+          // persistHead is scoped to attachTo; keep resume position roughly in
+          // sync by persisting through the same channel used by frameupdate.
+          const pid = projectIdRef.current;
+          const tid = timelineIdRef.current;
+          if (pid && tid) saveTimelineView(pid, tid, { playhead: clamped });
+        }
+      } else {
+        // Audio clock not available (gap, ended, buffering): hand the playhead
+        // back to the wall-clock frameupdate path.
+        lastAudioFrameRef.current = null;
+      }
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [playing, getAudibleItem]);
   useEffect(() => {
     const player = playerRef.current;
     if (player) restorePlayerRef.current(player);

--- a/src/components/timeline/usePlayheadPaint.verify.ts
+++ b/src/components/timeline/usePlayheadPaint.verify.ts
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  audioMediaTimeToTimelineFrame,
+  type AudibleAudioItem,
+} from './usePlayheadPaint';
+
+// Media time -> timeline frame mapping (marking-mode audio clock).
+// The audible media element reports SOURCE seconds; the timeline frame of the
+// audible content is item.startFrame + (mediaSeconds*fps - srcInFrame) / rate.
+
+const base: AudibleAudioItem = { startFrame: 0, playbackRate: 1, srcInFrame: 0, src: '/media/uploads/x.mp3' };
+
+// Plain rate-1, srcIn 0: frame == media seconds * fps (the marking workflow:
+// 0.5x-processed export played back at 1.0). The caller rounds to whole
+// frames, so assert through the same rounding.
+assert.equal(audioMediaTimeToTimelineFrame(1.0, base, 30), 30);
+assert.equal(Math.round(audioMediaTimeToTimelineFrame(11 / 30, base, 30)), 11);
+assert.equal(audioMediaTimeToTimelineFrame(0, base, 30), 0);
+
+// Item starting mid-timeline: the playhead offset shifts with the item start.
+assert.equal(audioMediaTimeToTimelineFrame(1.0, { ...base, startFrame: 820 }, 30), 850);
+
+// Source in-point: media time is measured from the trimmed-in source region.
+// srcInFrame 30 == 1s of leading source cut; media t=1s is then the window start.
+assert.equal(
+  audioMediaTimeToTimelineFrame(1.0, { ...base, srcInFrame: 30 }, 30),
+  0,
+  'srcInFrame shifts the mapping so media t=1s maps back to frame 0',
+);
+assert.equal(
+  audioMediaTimeToTimelineFrame(3.0, { ...base, srcInFrame: 30 }, 30),
+  60,
+);
+
+// Rate-stretched audio item: 0.5x means one source second covers two timeline
+// seconds worth of frames.
+assert.equal(
+  audioMediaTimeToTimelineFrame(2.0, { ...base, playbackRate: 0.5 }, 30),
+  120,
+  '0.5x: 2 media seconds == 120 timeline frames at 30fps',
+);
+
+// Negative / sub-frame results round naturally at the caller; the pure mapping
+// stays exact.
+assert.equal(audioMediaTimeToTimelineFrame(0.5, { ...base, srcInFrame: 30 }, 30), -15);
+
+// Wiring assertions: the controller must expose the audible audio item and the
+// paint hook must actually run the audio-clock loop while playing.
+const controllerSource = readFileSync(new URL('./useTimelineController.ts', import.meta.url), 'utf8');
+assert.match(
+  controllerSource,
+  /getAudibleItem = useCallback\(\\(playheadFrame: number\): AudibleAudioItem \| null =>/,
+  'controller must expose the audible audio item for marking mode',
+);
+assert.match(
+  controllerSource,
+  /it\.kind === 'audio' && !!it\.src/,
+  'only audio items qualify for the audio clock',
+);
+
+const paintSource = readFileSync(new URL('./usePlayheadPaint.ts', import.meta.url), 'utf8');
+assert.match(
+  paintSource,
+  /if \(lastAudioFrameRef\.current !== null\) return;/,
+  'wall-clock frameupdate must yield to the audio clock while marking mode is active',
+);
+assert.match(
+  paintSource,
+  /audioMediaTimeToTimelineFrame\(mediaSec, item, fpsRef\.current\)/,
+  'the audio-clock loop must map media time through the item geometry',
+);
+assert.match(
+  paintSource,
+  /lastAudioFrameRef\.current = null;/,
+  'the audio lock must release when no audible media element is available',
+);
+
+console.log('usePlayheadPaint.verify: marking-mode audio clock passed');

--- a/src/components/timeline/useTimelineController.ts
+++ b/src/components/timeline/useTimelineController.ts
@@ -26,7 +26,7 @@ import {
 import { newManualCaptions } from '../../captions/manualCaptions';
 import { useTimelineShortcuts } from './useTimelineShortcuts';
 import { useTimelinePointer } from './useTimelinePointer';
-import { usePlayheadPaint } from './usePlayheadPaint';
+import { usePlayheadPaint, type AudibleAudioItem } from './usePlayheadPaint';
 import { useTimelineZoomController } from './useTimelineZoomController';
 import { timelineFitTotalFrames } from './timelineFitRange';
 import {
@@ -99,11 +99,30 @@ export function useTimelineController({
     return { kind, color };
   };
   // Playhead drawing machine: rAF frame direct drawing + Player watchdog + breakpoint resume (usePlayheadPaint)
+  // Marking mode: expose the audible audio item at a playhead frame so the
+  // playhead / marker placement can follow the media element's own clock during
+  // playback (see usePlayheadPaint). Audio items are the source of truth for
+  // beat marking; video timelines keep the wall-clock behavior.
+  const getAudibleItem = useCallback((playheadFrame: number): AudibleAudioItem | null => {
+    const s = liveStateRef.current;
+    const audible = s.items.find((it) =>
+      it.kind === 'audio' && !!it.src && (it.volume ?? 1) > 0
+      && playheadFrame >= it.startFrame && playheadFrame < it.startFrame + it.durationInFrames
+      && !s.tracks?.[it.track]?.muted && !s.tracks?.[it.track]?.hidden,
+    );
+    if (!audible) return null;
+    return {
+      startFrame: audible.startFrame,
+      playbackRate: audible.playbackRate ?? 1,
+      srcInFrame: audible.srcInFrame ?? 0,
+      src: audible.src!,
+    };
+  }, []);
   const {
     playheadRef, playheadLineRef, toolbarTimecodeRef, rulerTimecodeRef,
     paintPlayhead, setTimecodePreviewFrame, playing,
   } =
-    usePlayheadPaint({ playerRef, projectId, timelineId, fps: state.fps, total, px });
+    usePlayheadPaint({ playerRef, projectId, timelineId, fps: state.fps, total, px, getAudibleItem });
   // editing mode (Selection V / Blade B / Trim N / Pen P). selection =
   // drag/move; blade = click a clip to cut it there; trim = edge-trim ripples
   // following clips; pen = draw opacity keyframes on the selected clip.
@@ -119,7 +138,7 @@ export function useTimelineController({
       ? true
       : captionTrackEntries(state).some((entry) => entry.captions?.enabled) || textClipCount > 0;
   const {
-    captionMenu, setCaptionMenu, trackMenu, setTrackMenu, transitionMenu, setTransitionMenu,
+    captionMenu, setCaptionMenu, trackMenu, setTrackMenu,
     captionError, setCaptionError, duckMenu, setDuckMenu,
     moveCaptionCue, openCaptionTrackMenu, openDuckTrackMenu,
     closeTrackDrillMenu, backFromTrackDrillMenu,
@@ -432,7 +451,7 @@ export function useTimelineController({
     commitTimelineSelectionMove, zoom, setZoom, px, trackScale, metaOf,
     playheadRef, playheadLineRef, toolbarTimecodeRef, rulerTimecodeRef,
     paintPlayhead, playing, editMode, placeMode, setPlaceMode, snapping,
-    captionsVisible, captionMenu, setCaptionMenu, trackMenu, setTrackMenu, transitionMenu, setTransitionMenu,
+    captionsVisible, captionMenu, setCaptionMenu, trackMenu, setTrackMenu,
     duckMenu, setDuckMenu, captionError, setCaptionError,
     moveCaptionCue, openCaptionTrackMenu, openDuckTrackMenu,
     closeTrackDrillMenu, backFromTrackDrillMenu, recorder, toggleCaptions,


### PR DESCRIPTION
## Summary

Adds a **marking mode** for audio timelines: while playing, the timeline playhead (and therefore every marker placed at it) follows the **audible media element's own clock** instead of the Remotion Player's wall-clock frame.

## Why

Beat-marking on audio tracks (0.5x-processed exports played back at 1.0) exposes a Remotion Player behavior: frames advance by `performance.now()` while audio advances on its own hardware clock. Any main-thread stall — e.g. rapid marker creation (`M` taps), autosave, or any re-render — makes the playhead run ahead of what is actually heard. Remotion deliberately does not re-sync below `ALLOWED_GLOBAL_TIME_ANCHOR_SHIFT (0.1s) + output latency` (`set-global-time-anchor.ts`), so:

1. The playhead visibly passes a marker **before** the corresponding beat is heard (drift within tolerance is never corrected).
2. When drift exceeds the threshold, the anchor is forcibly re-aligned — an audible glitch/stutter while time-stretched audio plays.

Symptoms are worst during high-frequency marking, which is exactly when the main thread stalls most.

## Change

- `usePlayheadPaint.ts`: while `playing` and an audible audio item exists, a rAF loop derives the playhead from the media element's `currentTime`, mapped through the item's `startFrame` / `playbackRate` / `srcInFrame` geometry (`audioMediaTimeToTimelineFrame`, pure + verified). The wall-clock `frameupdate` path yields while the audio clock owns the playhead; pausing prefers the last audio-clock frame so the playhead doesn't snap forward. WebAudio output latency is measured once and subtracted so markers land on the audible beat.
- `useTimelineController.ts`: exposes `getAudibleItem(playheadFrame)` — the audible (unmuted, visible-track, in-range) audio item — via a stable `useCallback` over the live state ref.
- `usePlayheadPaint.verify.ts`: unit coverage for the media-time→frame mapping (rate, srcIn, start offset) plus wiring assertions.

Video timelines keep the existing wall-clock behavior (video elements are already frame-synced by Remotion); the change is a strict improvement for audio-only marking and a no-op elsewhere (no video item matches `kind === 'audio'`).

## Verification

- `npx tsx src/components/timeline/usePlayheadPaint.verify.ts` — PASS
- `npx tsx src/components/timeline/timelineSeek.verify.ts` / `timelineWindow.verify.ts` — PASS
- `npx tsc -b` — clean
- `npm run build` (vite) — clean