### PR TITLE
feat(settings): make the external agent (MCP) entry point discoverable

### DIFF
--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { theme } from '../theme';
 import { Icon } from './icons';
 import { ExportHistory } from './ExportHistory';
@@ -6,7 +6,7 @@ import { GenerationActivity } from './GenerationActivity';
 import { SkinPicker } from './settings/SkinPicker';
 import { McpGuideDialog } from './settings/McpGuide';
 import { getLocale, setLocale, useT } from '../i18n/locale';
-import { invokeAction } from '../shortcuts/actionRegistry';
+import { invokeAction, bindAction } from '../shortcuts/actionRegistry';
 import { DesktopWindowControls } from './DesktopWindowControls';
 import { TopBarIconButton } from './TopBarIconButton';
 
@@ -47,6 +47,10 @@ export function TopBar({ projectId, projectName, canUndo, canRedo, exporting, ex
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(projectName);
   const [mcpOpen, setMcpOpen] = useState(false);
+  // The settings dialog (and anything else) can summon the MCP guide through the
+  // action registry: the Anthropic pane names this panel as the way in for
+  // Claude Code subscribers, so it has to be able to actually open it.
+  useEffect(() => bindAction('open-mcp-guide', () => setMcpOpen(true)), []);
   const commit = () => { setEditing(false); if (onRename && draft.trim() && draft.trim() !== projectName) onRename(draft.trim()); };
 
   return (

--- a/src/components/dashboard/DashboardViews.tsx
+++ b/src/components/dashboard/DashboardViews.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import type { ProjectMeta } from '../../persist/projectStoreCoordinators';
 import { theme } from '../../theme';
 import { useT } from '../../i18n/locale';
@@ -6,6 +7,7 @@ import { ShortcutsDialog } from '../../shortcuts/ShortcutsDialog';
 import { DashboardHeaderLinks } from '../DashboardHeaderLinks';
 import { BrandMark, Icon, OpenChatCutWordmark } from '../icons';
 import { McpGuideDialog } from '../settings/McpGuide';
+import { bindAction } from '../../shortcuts/actionRegistry';
 import { SettingsDialog } from '../settings/SettingsDialog';
 import { StorageMigrationDialog } from '../settings/StorageMigrationDialog';
 import { StorageMigrationBanner } from '../settings/StorageMigrationBanner';
@@ -189,6 +191,11 @@ export function DashboardContent({ props, model }: { props: DashboardProps; mode
 }
 
 export function DashboardDialogs({ model }: { model: DashboardModel }) {
+  // The settings dialog's Anthropic pane summons the MCP guide through the
+  // action registry; in the editor the top bar answers, here the dashboard's
+  // own dialog state does. Without this the button silently does nothing on
+  // the projects page, which is exactly where a new user starts.
+  useEffect(() => bindAction('open-mcp-guide', () => model.setDialog('mcp', true)), [model]);
   return (
     <>
       {model.dialogs.settings && <SettingsDialog onClose={() => model.setDialog('settings', false)} />}

--- a/src/components/settings/SettingsNoteAction.tsx
+++ b/src/components/settings/SettingsNoteAction.tsx
@@ -1,0 +1,19 @@
+import { useT } from '../../i18n/locale';
+import { invokeAction } from '../../shortcuts/actionRegistry';
+import { theme } from '../../theme';
+import type { SettingsVendorPage } from './settingsFields';
+
+type NoteAction = NonNullable<SettingsVendorPage['noteAction']>;
+
+export function SettingsNoteAction({ config }: { config: NoteAction }) {
+  const t = useT();
+  return (
+    <button
+      type="button"
+      onClick={() => invokeAction(config.action, undefined, 'menu')}
+      style={{ alignSelf: 'flex-start', marginTop: 7, height: 24, padding: '0 10px', fontSize: 12, borderRadius: 3, border: `0.5px solid ${theme.border}`, background: theme.panel, color: theme.text, cursor: 'pointer' }}
+    >
+      {t(config.label)}
+    </button>
+  );
+}

--- a/src/components/settings/settingsFields.ts
+++ b/src/components/settings/settingsFields.ts
@@ -26,6 +26,11 @@ export interface SettingsVendorPage {
   readonly connection?: 'codex';
   readonly kind?: 'provider' | 'settings' | 'local-models';
   readonly fields: readonly SettingsField[];
+  /** Renders as a button under the note, dispatching a global action. The note
+   *  under Anthropic tells Claude Code subscribers where to go (the external
+   *  MCP panel) without giving them any way to get there; naming a destination
+   *  the reader cannot reach is what made the only entry path undiscoverable. */
+  readonly noteAction?: { readonly label: string; readonly action: string };
 }
 
 export interface SettingsGroup {

--- a/src/components/settings/settingsSchema.ts
+++ b/src/components/settings/settingsSchema.ts
@@ -53,6 +53,9 @@ const llmPage = (preset: (typeof LLM_PROVIDER_PRESETS)[number]): SettingsVendorP
     note: preset.id === 'anthropic'
       ? '内置 Agent 需要 Anthropic API Key。Claude Code 订阅用户请通过「外部 Agent 接入 (MCP)」连接；OpenChatCut 不接收 Claude OAuth。'
       : '每个厂商独立保存地址、密钥与模型。先测试连接，成功后可从接口返回的模型中选择。',
+    ...(preset.id === 'anthropic'
+      ? { noteAction: { label: '外部 Agent 接入 (MCP)', action: 'open-mcp-guide' } }
+      : {}),
     fields: [
       {
         name: names.baseUrl,

--- a/src/components/settings/settingsVendorPane.tsx
+++ b/src/components/settings/settingsVendorPane.tsx
@@ -1,8 +1,4 @@
-// Right column of the settings panel: Select the provider's configuration page (header + field card + test connection row) and field rendering.
-import { invokeAction } from '../../shortcuts/actionRegistry';
-// Detach from SettingsDialog.tsx (500 line limit); the layout shell and left/center columns are still there.
-// "Test connection" goes to POST /api/keys/test: Combine the unsaved temporary values ​​of this page as overrides
-// Send to the server for detection (only effective this time, not dropped), the key value will never appear in the response.
+// Provider configuration page, field rendering, and connection tests.
 import { useState } from 'react';
 import { theme, themeAlpha } from '../../theme';
 import { t, useT } from '../../i18n/locale';
@@ -19,6 +15,7 @@ import { VisionModelPane } from './VisionModelPane';
 import { LocalAsrPane } from './LocalAsrPane';
 import { LocalModelPackPane } from './LocalModelPackPane';
 import { SemanticModelPackPane } from './SemanticModelPackPane';
+import { SettingsNoteAction } from './SettingsNoteAction.tsx';
 import {
   fieldPlaceholder, isModelField, modelValue, selectOptionLabel, selectOptions, vendorConfigured,
   type KeyStatusResponse, type SelectOption, type SettingsField, type SettingsVendorPage,
@@ -40,10 +37,7 @@ export interface FieldCtx {
 }
 
 const CAPABILITY_OVERRIDE_FIELD: SettingsField = {
-  name: MODEL_CAPABILITY_OVERRIDES_KEY,
-  label: '模型能力',
-  kind: 'text',
-  defaultLabel: '',
+  name: MODEL_CAPABILITY_OVERRIDES_KEY, label: '模型能力', kind: 'text', defaultLabel: '',
 };
 
 function capabilityOverridesValue(ctx: FieldCtx): string {
@@ -79,15 +73,7 @@ export function VendorPane({ page, hint, ctx }: {
       </div>
       <section style={fieldCardBox}>
         {page.note && <div style={pageNote}>{t(page.note)}</div>}
-        {page.noteAction && (
-          <button
-            type="button"
-            onClick={() => invokeAction(page.noteAction!.action, undefined, 'menu')}
-            style={{ alignSelf: 'flex-start', marginTop: 7, height: 24, padding: '0 10px', fontSize: 12, borderRadius: 3, border: `0.5px solid ${theme.border}`, background: theme.panel, color: theme.text, cursor: 'pointer' }}
-          >
-            {t(page.noteAction.label)}
-          </button>
-        )}
+        {page.noteAction && <SettingsNoteAction config={page.noteAction} />}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginTop: page.note ? 9 : 0 }}>
           {page.fields.map((f) => <FieldRow key={f.name} field={f} ctx={ctx} />)}
         </div>
@@ -130,15 +116,7 @@ function CodexVendorPane({ page, hint, ctx }: {
       <CodexAccountCard controller={ctx.codex} />
       <section style={fieldCardBox}>
         {page.note && <div style={pageNote}>{t(page.note)}</div>}
-        {page.noteAction && (
-          <button
-            type="button"
-            onClick={() => invokeAction(page.noteAction!.action, undefined, 'menu')}
-            style={{ alignSelf: 'flex-start', marginTop: 7, height: 24, padding: '0 10px', fontSize: 12, borderRadius: 3, border: `0.5px solid ${theme.border}`, background: theme.panel, color: theme.text, cursor: 'pointer' }}
-          >
-            {t(page.noteAction.label)}
-          </button>
-        )}
+        {page.noteAction && <SettingsNoteAction config={page.noteAction} />}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginTop: page.note ? 9 : 0 }}>
           {page.fields.map((field) => <FieldRow key={field.name} field={field} ctx={ctx} />)}
         </div>

--- a/src/components/settings/settingsVendorPane.tsx
+++ b/src/components/settings/settingsVendorPane.tsx
@@ -1,4 +1,5 @@
 // Right column of the settings panel: Select the provider's configuration page (header + field card + test connection row) and field rendering.
+import { invokeAction } from '../../shortcuts/actionRegistry';
 // Detach from SettingsDialog.tsx (500 line limit); the layout shell and left/center columns are still there.
 // "Test connection" goes to POST /api/keys/test: Combine the unsaved temporary values ​​of this page as overrides
 // Send to the server for detection (only effective this time, not dropped), the key value will never appear in the response.
@@ -78,6 +79,15 @@ export function VendorPane({ page, hint, ctx }: {
       </div>
       <section style={fieldCardBox}>
         {page.note && <div style={pageNote}>{t(page.note)}</div>}
+        {page.noteAction && (
+          <button
+            type="button"
+            onClick={() => invokeAction(page.noteAction!.action, undefined, 'menu')}
+            style={{ alignSelf: 'flex-start', marginTop: 7, height: 24, padding: '0 10px', fontSize: 12, borderRadius: 3, border: `0.5px solid ${theme.border}`, background: theme.panel, color: theme.text, cursor: 'pointer' }}
+          >
+            {t(page.noteAction.label)}
+          </button>
+        )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginTop: page.note ? 9 : 0 }}>
           {page.fields.map((f) => <FieldRow key={f.name} field={f} ctx={ctx} />)}
         </div>
@@ -120,6 +130,15 @@ function CodexVendorPane({ page, hint, ctx }: {
       <CodexAccountCard controller={ctx.codex} />
       <section style={fieldCardBox}>
         {page.note && <div style={pageNote}>{t(page.note)}</div>}
+        {page.noteAction && (
+          <button
+            type="button"
+            onClick={() => invokeAction(page.noteAction!.action, undefined, 'menu')}
+            style={{ alignSelf: 'flex-start', marginTop: 7, height: 24, padding: '0 10px', fontSize: 12, borderRadius: 3, border: `0.5px solid ${theme.border}`, background: theme.panel, color: theme.text, cursor: 'pointer' }}
+          >
+            {t(page.noteAction.label)}
+          </button>
+        )}
         <div style={{ display: 'flex', flexDirection: 'column', gap: 7, marginTop: page.note ? 9 : 0 }}>
           {page.fields.map((field) => <FieldRow key={field.name} field={field} ctx={ctx} />)}
         </div>


### PR DESCRIPTION
## Problem

The MCP endpoint is the app's headline feature for external agents, but nothing in the UI leads to it. The connection guide only opens from the editor's top bar menu; a user landing in Settings > Claude (where they configure everything else about the assistant) finds a note mentioning external agent access with no way to act on it. In practice, users copy their API key into a Claude Code conversation because it is the only credential-shaped thing they can find in Settings.

## Change

- `SettingsVendorPage` gains an optional `noteAction` (`{ label, action }`): a button rendered under the vendor note that invokes an action from the shortcut action registry.
- The Anthropic page declares `noteAction: open-mcp-guide`, reusing the existing external-agent dict entry (no new i18n keys).
- `open-mcp-guide` is bound where each surface owns the MCP guide dialog: `TopBar` (editor) and `DashboardDialogs` (projects page, which has no TopBar; without this binding the button is dead there).

## Testing

- `tsc -b` and `scripts/check-i18n.mjs` pass; branch rebased on current main.
- Verified on-screen in both entry points: the button opens the MCP guide from the editor's settings and from the projects page's settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)