### PR TITLE
fix(external-agent): keep awaiting_review proposals reviewable when the run record is gone

### DIFF
--- a/src/agent/external-bridge-hydration.ts
+++ b/src/agent/external-bridge-hydration.ts
@@ -1,5 +1,6 @@
 import type { ProjectDoc } from '../editor/types';
 import { replayActions } from '../editor/store';
+import { loadAgentRuntimeSidecar } from '../persist/agentRuntimeStore';
 import type { StoredExternalProposal } from '../persist/externalProposalStore';
 import type { ExternalBridgePersistence } from './external-proposal-apply';
 import {
@@ -118,7 +119,16 @@ export async function hydrateStoredExternalBridge(input: ExternalBridgeHydration
     ? await ExternalSessionRunLedger.resume(input.projectId, runId, input.executeTool)
     : null;
   if (runId && !run) {
-    throw new Error('External proposal is active in another editor or no longer resumable.');
+    const runRecordGone = !(await loadAgentRuntimeSidecar(input.projectId))
+      .runs.some((entry) => entry.runId === runId);
+    if (!runRecordGone) {
+      // The run still exists but is claimed by another active editor — do not
+      // steal ownership, and do not apply its proposal here.
+      throw new Error('External proposal is active in another editor or no longer resumable.');
+    }
+    // The run record is gone (e.g. the editor/server restarted before the run
+    // was persisted). The awaiting_review proposal is complete on disk, so keep
+    // it reviewable: apply/reject/discard work without the run ledger.
   }
   if (run) await prepareHydratedRun(run);
   input.install({ session, run });

--- a/src/agent/external-bridge-runtime.ts
+++ b/src/agent/external-bridge-runtime.ts
@@ -240,8 +240,8 @@ export class ExternalBridgeRuntime {
     const session = this.currentProposalSession();
     const proposal = session?.proposal;
     if (!session || !proposal) return;
-    const run = this.requireRun(session.id);
-    await run.confirmOwnership();
+    const run = this.runs.get(session.id);
+    if (run) await run.confirmOwnership();
     throwIfExternalCallCancelled(signal);
     const context = this.getContext();
     const committed = await commitExternalProposal({
@@ -294,7 +294,8 @@ export class ExternalBridgeRuntime {
   async reject(): Promise<void> {
     const session = this.currentProposalSession();
     if (!session) return;
-    await this.requireRun(session.id).confirmOwnership();
+    const run = this.runs.get(session.id);
+    if (run) await run.confirmOwnership();
     await this.complete(session, 'rejected');
   }
 

--- a/src/agent/external-edit-session-runtime.verify.ts
+++ b/src/agent/external-edit-session-runtime.verify.ts
@@ -286,6 +286,57 @@ const awaitingInfo = await reviewRuntime.execute(
   runtimeBinding,
 );
 assert.equal(sessionStatus(awaitingInfo), 'awaiting_review');
+
+// A persisted awaiting_review proposal whose agent run record is gone (e.g. the
+// editor/server restarted before the run was persisted) must stay reviewable
+// instead of orphaning the editor, and reject/apply must not require the run.
+const recoveredLive = makeDraft(base);
+const recoveredRuntime = new ExternalBridgeRuntime(
+  'runtime-project',
+  'runtime-editor',
+  () => ({
+    commands: recoveredLive.commands,
+    getState: recoveredLive.getState,
+    getDoc: recoveredLive.getDoc,
+    getCreativeMode: () => null,
+    templates: [],
+    audio: [],
+    getProjectId: () => 'runtime-project',
+  }),
+  () => undefined,
+);
+await recoveredRuntime.hydrate({
+  sessionId: reviewed.id,
+  clientName: reviewed.clientName,
+  approvalMode: 'manual',
+  status: 'awaiting_review',
+  baseRevision: reviewed.baseRevision,
+  createdAt: reviewed.createdAt,
+  operationCount: reviewed.operationCount,
+  agentRunId: 'run_missing_after_restart',
+  proposal: reviewed.proposal,
+});
+const recoveredInfo = await recoveredRuntime.execute(
+  'get_edit_session',
+  { editSessionId: reviewed.id },
+  runtimeBinding,
+);
+assert.equal(
+  sessionStatus(recoveredInfo),
+  'awaiting_review',
+  'an awaiting_review proposal whose run record is gone stays reviewable instead of throwing',
+);
+await recoveredRuntime.reject();
+const recoveredRejected = await recoveredRuntime.execute(
+  'get_edit_session',
+  { editSessionId: reviewed.id },
+  runtimeBinding,
+);
+assert.equal(
+  sessionStatus(recoveredRejected),
+  'rejected',
+  'rejecting a run-less recovered proposal does not require the run ledger',
+);
 assert(isExternalDraftTool('set_aspect_ratio'));
 assert(isExternalReadTool('read_project'));
 assert(isExternalReadTool('search_stock_media'));


### PR DESCRIPTION
## Problem

A persisted `awaiting_review` external edit session whose agent run record no longer exists (e.g. the editor/server restarted before the run was persisted) currently fails hydration with `External proposal is active in another editor or no longer resumable.` This orphans the proposal permanently: it can never be applied, rejected, or discarded, and the project's external-edit surface is blocked (the UI also surfaces `Agent run for edit session ... is unavailable`).

## Root cause

`hydrateStoredExternalBridge` treats two different situations identically when `ExternalSessionRunLedger.resume()` returns `null`:

1. the run still exists but is claimed by another **active** editor — must not steal ownership;
2. the run record is **gone** entirely — the `awaiting_review` proposal is complete on disk and only needs the run ledger for durable artifact recording, not for review/apply/reject.

Case 2 should degrade gracefully instead of throwing, but the current code throws for both.

## Fix

- `external-bridge-hydration.ts`: when the run cannot be resumed, check whether the run record actually still exists via `loadAgentRuntimeSidecar`. Only throw when the record exists (owned elsewhere). When the record is gone, install the restored session with `run: null` and keep the `awaiting_review` proposal reviewable.
- `external-bridge-runtime.ts`: `apply()` and `reject()` no longer hard-require the run ledger (`requireRun` + `confirmOwnership`); they confirm ownership only when a run is present. `discard()`/`markTerminal` were already null-safe.
- `external-edit-session-runtime.verify.ts`: new check that an `awaiting_review` proposal with a missing run record hydrates as reviewable and can be rejected.

## Verification

- `npx tsc -b --force` ✅
- `npm run lint` ✅ (0 errors)
- `npm run build` (tsc -b && vite build) ✅
- `npm test` ✅ (full suite)