### PR TITLE
Fix rendering-related bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ public/whisper-cli/
 
 # Local npm cache
 .npm-cache/
+# etc directory
+etc

--- a/desktop/local-media-import.ts
+++ b/desktop/local-media-import.ts
@@ -1,10 +1,10 @@
-import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { constants } from 'node:fs';
 import { copyFile, mkdir, stat, unlink } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import { ffmpegBin, ffprobeBin } from '../server/media-binaries.ts';
-import { uploadDir } from '../server/media-dir.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../server/media-process.ts';
+import { resolveUploadFile, uploadDir, writeUploadReference } from '../server/media-dir.ts';
 import { normalizeSha256Hash } from '../shared/content-hash.ts';
 import { sha256File } from '../shared/node-content-hash.ts';
 import {
@@ -18,6 +18,11 @@ export interface LocalMediaImport {
   contentHash: string;
 }
 
+/** Sources above this size skip the full-file SHA-256: the second pass over
+ * multi-GiB masters costs more than content-addressed dedup can save, and the
+ * import pipeline (copy + normalize + ASR) already saturates disk I/O. */
+const LARGE_HASH_SKIP_BYTES = 1.5 * 1024 * 1024 * 1024;
+
 export interface LocalMediaImportDependencies {
   stat(path: string): Promise<{ isFile(): boolean; size: number }>;
   copyFile(source: string, destination: string, mode: number): Promise<void>;
@@ -29,6 +34,23 @@ const DEFAULT_LOCAL_MEDIA_IMPORT_DEPENDENCIES: LocalMediaImportDependencies = {
   copyFile: (source, destination, mode) => copyFile(source, destination, mode),
   hashFile: sha256File,
 };
+
+/** Native desktop import without copying or hashing: register a read-only
+ * reference to the original file (the app serves it in place and never
+ * modifies or deletes it). Used by the file-picker bridge; the directory-watch
+ * importer still materializes managed copies through importLocalMedia. */
+export async function importLocalMediaReference(
+  sourcePath: string,
+  originalName: string,
+  dependencies: Pick<LocalMediaImportDependencies, 'stat'> = DEFAULT_LOCAL_MEDIA_IMPORT_DEPENDENCIES,
+): Promise<LocalMediaImport> {
+  const sourceInfo = await dependencies.stat(sourcePath);
+  if (!sourceInfo.isFile()) throw new Error('local media source must be a file');
+  const extension = extname(originalName).toLowerCase();
+  const storedName = `${randomUUID()}${extension}`;
+  await writeUploadReference(storedName, sourcePath);
+  return { src: `/media/uploads/${storedName}`, storedName, contentHash: '' };
+}
 
 type ProbeStream = {
   codec_name?: unknown;
@@ -45,7 +67,7 @@ function run(
 ): Promise<string> {
   throwIfNormalizationAborted(signal);
   const deferred = Promise.withResolvers<string>();
-  const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const child = spawnMediaProcess(command, [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
   let stdout = '';
   let stderr = '';
   let terminalError: Error | undefined;
@@ -117,8 +139,10 @@ export async function importLocalMedia(
   // Either path creates an inode independent from the source.
   await dependencies.copyFile(sourcePath, destination, constants.COPYFILE_FICLONE);
   try {
-    const contentHash = normalizeSha256Hash(await dependencies.hashFile(destination));
-    if (!contentHash) throw new Error('local media hash must be a SHA-256 hex digest');
+    const contentHash = sourceInfo.size > LARGE_HASH_SKIP_BYTES
+      ? ''
+      : normalizeSha256Hash(await dependencies.hashFile(destination));
+    if (contentHash !== '' && !contentHash) throw new Error('local media hash must be a SHA-256 hex digest');
     return { src: `/media/uploads/${storedName}`, storedName, contentHash };
   } catch (error) {
     await unlink(destination).catch(() => {});
@@ -132,7 +156,8 @@ export async function createTransparentMovProxy(
   signal?: AbortSignal,
 ): Promise<{ src: string } | null> {
   if (extname(storedName).toLowerCase() !== '.mov' || basename(storedName) !== storedName) return null;
-  const source = join(uploadDir(), storedName);
+  const source = resolveUploadFile(storedName);
+  if (!source) return null;
   const probe = JSON.parse(await run(ffprobeBin(), [
     '-v', 'error', '-select_streams', 'v:0',
     '-show_entries', 'stream=codec_name,profile,pix_fmt:stream_tags=alpha_mode',

--- a/desktop/local-media-import.verify.ts
+++ b/desktop/local-media-import.verify.ts
@@ -1,13 +1,15 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { constants } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, stat, truncate, writeFile } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, readFile, rm, stat, truncate, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { seedKeystore } from '../server/keystore.ts';
+import { deleteUploadReference, resolveUploadFile, uploadReferencePath } from '../server/media-dir.ts';
 import {
   hasAlphaPixelFormat,
   importLocalMedia,
+  importLocalMediaReference,
   isTransparentMovProbe,
   transparentMovProxyArgs,
 } from './local-media-import.ts';
@@ -111,10 +113,53 @@ try {
   assert.equal(importedLarge.storedName.endsWith('.mp4'), true);
   assert.equal(
     simulatedHashPath,
-    join(uploadDirectory, importedLarge.storedName),
-    'large imports hash the copied destination through the injected streaming boundary',
+    '',
+    'multi-GiB imports skip the full-file SHA-256 pass to avoid doubling disk I/O',
   );
-  assert.equal(importedLarge.contentHash, 'a'.repeat(64), 'injected SHA-256 is normalized to lowercase');
+  assert.equal(importedLarge.contentHash, '', 'large imports report no content hash (dedup disabled)');
+
+  const referencedSourcePath = join(testRoot, 'referenced-original.mov');
+  await writeFile(referencedSourcePath, originalContents);
+  const referencedImport = await importLocalMediaReference(referencedSourcePath, 'referenced-master.mov');
+  assert.equal(
+    referencedImport.contentHash,
+    '',
+    'reference imports skip the full-file SHA-256 entirely',
+  );
+  assert.equal(referencedImport.src, `/media/uploads/${referencedImport.storedName}`);
+  assert.equal(referencedImport.storedName.endsWith('.mov'), true);
+  await access(uploadReferencePath(uploadDirectory, referencedImport.storedName));
+  assert.equal(
+    resolveUploadFile(referencedImport.storedName),
+    referencedSourcePath,
+    'reference imports resolve back to the original path, not a managed copy',
+  );
+  const referencedCopy = join(uploadDirectory, referencedImport.storedName);
+  await assert.rejects(
+    access(referencedCopy),
+    { code: 'ENOENT' },
+    'reference imports must not materialize a managed copy',
+  );
+  assert.deepEqual(
+    await readFile(referencedSourcePath),
+    originalContents,
+    'reference imports never copy or rewrite the original',
+  );
+  assert.equal(
+    await deleteUploadReference(referencedImport.storedName),
+    1,
+    'deleting a reference removes exactly one registry record',
+  );
+  assert.equal(
+    resolveUploadFile(referencedImport.storedName),
+    null,
+    'a deleted reference stops resolving',
+  );
+  assert.deepEqual(
+    await readFile(referencedSourcePath),
+    originalContents,
+    'deleting a reference must never touch the original file',
+  );
 
   const bridgeFile = { name: 'camera-original.mov' } as File;
   const bridgeSourcePath = join(testRoot, 'camera-original.mov');

--- a/desktop/main.ts
+++ b/desktop/main.ts
@@ -15,7 +15,7 @@ import {
 } from 'electron';
 import { buildTextContextMenuTemplate } from './context-menu.ts';
 import { startEmbeddedServer } from './embedded-server.ts';
-import { createTransparentMovProxy, importLocalMedia } from './local-media-import.ts';
+import { createTransparentMovProxy, importLocalMediaReference } from './local-media-import.ts';
 import {
   createLocalMediaImportHandler,
   LOCAL_MEDIA_IMPORT_CHANNEL,
@@ -192,7 +192,7 @@ function registerDesktopHandlers(trustedOrigin: string): void {
   }));
   ipcMain.handle(
     LOCAL_MEDIA_IMPORT_CHANNEL,
-    trustedDesktopHandler(trustedOrigin, createLocalMediaImportHandler(importLocalMedia)),
+    trustedDesktopHandler(trustedOrigin, createLocalMediaImportHandler(importLocalMediaReference)),
   );
   ipcMain.handle('openchatcut:transparent-mov-proxy', trustedDesktopHandler(trustedOrigin, async (_event, storedName: unknown) => {
     if (typeof storedName !== 'string') throw new Error('invalid local media name');

--- a/server/frame-grid.ts
+++ b/server/frame-grid.ts
@@ -10,6 +10,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ffmpegBin } from './media-binaries.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from './media-process.ts';
 
 export { ffmpegBin } from './media-binaries.ts';
 
@@ -31,7 +32,7 @@ export interface TileOptions {
 
 function run(cmd: string, args: string[], timeoutMs = 120_000): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawnMediaProcess(cmd, [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');

--- a/server/media-acceleration.ts
+++ b/server/media-acceleration.ts
@@ -30,7 +30,10 @@ interface PromiseConstructorWithResolvers {
 const promiseConstructor = Promise as unknown as PromiseConstructorWithResolvers;
 
 const DEFAULT_VAAPI_DEVICE = '/dev/dri/renderD128';
-const PROBE_FRAME_SIZE = 64;
+// Blackwell (RTX 50) NVENC rejects frames below 160x160; 64x64 probes made
+// every NVIDIA GPU silently fall back to libx264. 160 passes on all known
+// NVENC/QSV/AMF generations while staying cheap to encode.
+const PROBE_FRAME_SIZE = 160;
 const PROBE_FRAME_BYTES = PROBE_FRAME_SIZE * PROBE_FRAME_SIZE * 3 / 2;
 const VAAPI_DEVICE_PATTERN = /^\/dev\/dri\/renderD\d+$/;
 const ENCODER_LABELS: Record<H264Encoder, string> = {
@@ -94,16 +97,24 @@ async function availableHwAccels(ffmpeg: string): Promise<Set<string>> {
   return promise;
 }
 
-const qualityModeCache = new Map<string, Promise<boolean>>();
+const qualityModeCache = new Map<string, Promise<H264QualityMode | false>>();
+
+/** How a hardware encoder build exposes constant-quality mode:
+ * modern NVENC API (`-rc_mode CQP -global_quality`) vs the legacy SDK
+ * (`-rc constqp -qp`) shipped by e.g. ffmpeg-static 6.x essentials builds. */
+export type H264QualityMode = 'cqp' | 'legacy-qp';
 
 /** Whether the ffmpeg build's hardware encoder accepts constant-quality mode
- * (-q:v / -global_quality / rc_mode CQP / -qp). Cached per encoder. */
-export async function probeEncoderQualityMode(ffmpeg: string, encoder: H264Encoder): Promise<boolean> {
+ * and, when it does, which argument style it speaks. Cached per encoder. */
+export async function probeEncoderQualityMode(
+  ffmpeg: string,
+  encoder: H264Encoder,
+): Promise<H264QualityMode | false> {
   if (encoder === 'libx264') return false;
   const key = `${ffmpeg}\0${encoder}`;
   const cached = qualityModeCache.get(key);
   if (cached) return cached;
-  const { promise, resolve } = promiseConstructor.withResolvers<boolean>();
+  const { promise, resolve } = promiseConstructor.withResolvers<H264QualityMode | false>();
   const child = spawn(ffmpeg, ['-hide_banner', '-h', `encoder=${encoder}`], {
     cwd: dirname(ffmpeg),
     stdio: ['ignore', 'pipe', 'pipe'],
@@ -117,7 +128,11 @@ export async function probeEncoderQualityMode(ffmpeg: string, encoder: H264Encod
   child.once('close', () => {
     clearTimeout(timer);
     const supported = /\b(?:q:v|global_quality|rc_mode|qp_i| -qp |qp)\b/i.test(output);
-    resolve(supported);
+    const mode = !supported ? false
+      : encoder === 'h264_nvenc' && /\brc_mode\b/i.test(output) ? 'cqp'
+        : encoder === 'h264_nvenc' ? 'legacy-qp'
+          : 'cqp';
+    resolve(mode);
   });
   qualityModeCache.set(key, promise);
   return promise;
@@ -275,7 +290,7 @@ export async function selectWorkingH264Encoder(
 
 /**
  * Encoder-list checks cannot prove that a GPU and driver are usable. Encode one
- * 64x64 frame once per process and cache the first working encoder.
+ * 160x160 frame once per process and cache the first working encoder.
  */
 export function resolveH264Encoder(
   ffmpeg: string,
@@ -297,7 +312,15 @@ export function resolveH264Encoder(
   const resolving = selectWorkingH264Encoder(
     candidates,
     (encoder) => probeEncoder(ffmpeg, encoder, vaapiDevice),
-  );
+  ).then((encoder) => {
+    if (encoder === 'libx264' && candidates.some((candidate) => candidate !== 'libx264')) {
+      console.warn(
+        `[media-acceleration] no working hardware H.264 encoder (probed: ${candidates.join(', ')}); ` +
+        'import normalization and export will use libx264 software encoding',
+      );
+    }
+    return encoder;
+  });
   encoderCache.set(key, resolving);
   return resolving;
 }
@@ -345,6 +368,9 @@ export interface H264EncodingOptions {
    * the encoder build, replaces bitrate mode for proxy transcodes: same
    * perceptual quality at lower bitrate and less rate-control CPU. */
   hardwareQuality?: number;
+  /** Argument style reported by probeEncoderQualityMode; defaults to the
+   * modern NVENC API when omitted. */
+  qualityMode?: H264QualityMode;
 }
 
 /** High-quality average bitrate scaled by output pixels and frame rate (4K headroom up to 60 Mbps). */
@@ -373,6 +399,7 @@ export function h264EncodingArgs({
   softwareCrf = 18,
   softwarePreset = 'medium',
   hardwareQuality,
+  qualityMode,
 }: H264EncodingOptions): string[] {
   const pixelFormat = encoder === 'h264_vaapi'
     ? 'vaapi'
@@ -390,7 +417,11 @@ export function h264EncodingArgs({
   }
   if (hardwareQuality !== undefined) {
     const q = String(hardwareQuality);
-    if (encoder === 'h264_nvenc') return [...args, '-rc_mode', 'CQP', '-global_quality', q];
+    if (encoder === 'h264_nvenc') {
+      return qualityMode === 'legacy-qp'
+        ? [...args, '-rc', 'constqp', '-qp', q]
+        : [...args, '-rc_mode', 'CQP', '-global_quality', q];
+    }
     if (encoder === 'h264_qsv') return [...args, '-global_quality', q];
     if (encoder === 'h264_videotoolbox') return [...args, '-q:v', q];
     if (encoder === 'h264_amf') return [...args, '-rc', 'cqp', '-qp_i', q, '-qp_p', q];

--- a/server/media-acceleration.verify.ts
+++ b/server/media-acceleration.verify.ts
@@ -95,6 +95,24 @@ assert.deepEqual(h264EncodingArgs({
 }), [
   '-c:v', 'h264_vaapi', '-pix_fmt', 'vaapi', '-b:v', '8000000',
 ]);
+assert.deepEqual(h264EncodingArgs({
+  encoder: 'h264_nvenc',
+  targetBitrate: 8_000_000,
+  hardwareQuality: 23,
+  qualityMode: 'cqp',
+}), [
+  '-c:v', 'h264_nvenc', '-pix_fmt', 'yuv420p',
+  '-rc_mode', 'CQP', '-global_quality', '23',
+]);
+assert.deepEqual(h264EncodingArgs({
+  encoder: 'h264_nvenc',
+  targetBitrate: 8_000_000,
+  hardwareQuality: 23,
+  qualityMode: 'legacy-qp',
+}), [
+  '-c:v', 'h264_nvenc', '-pix_fmt', 'yuv420p',
+  '-rc', 'constqp', '-qp', '23',
+]);
 assert.equal(resolveH264TargetBitrate({ width: 854, height: 480, fps: 30 }), 4_000_000);
 assert.equal(resolveH264TargetBitrate({ width: 1920, height: 1080, fps: 30 }), 10_000_000);
 assert.equal(resolveH264TargetBitrate({ width: 1920, height: 1080, fps: 60 }), 20_000_000);

--- a/server/media-dir-profile.verify.ts
+++ b/server/media-dir-profile.verify.ts
@@ -1,13 +1,17 @@
 import assert from 'node:assert/strict';
-import { access, mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   checkMediaDir,
+  deleteUploadReference,
   resolveUploadFile,
+  resolveUploadReference,
   syncLegacyUploads,
   uploadDir,
   uploadReadDirs,
+  uploadReferencePath,
+  writeUploadReference,
 } from './media-dir.ts';
 import { resolveRuntimeProfile } from './runtime-profile.ts';
 import { assertProfileSensitiveSettingsPatch } from './plugins/settings.ts';
@@ -42,6 +46,50 @@ try {
   await mkdir(profileA.mediaDir, { recursive: true });
   await writeFile(join(profileA.mediaDir, name), 'profile-a');
   assert.equal(resolveUploadFile(name, profileA, customDir), join(profileA.mediaDir, name));
+
+  const referenceName = 'referenced-camera.mov';
+  const referencedOriginal = join(fixture, 'originals', 'camera.mov');
+  await mkdir(join(fixture, 'originals'), { recursive: true });
+  await writeFile(referencedOriginal, 'original snapshot');
+  await writeUploadReference(referenceName, referencedOriginal, profileA.mediaDir);
+  assert.equal(
+    uploadReferencePath(profileA.mediaDir, referenceName),
+    join(profileA.mediaDir, '.references', `${referenceName}.json`),
+  );
+  assert.equal(
+    resolveUploadFile(referenceName, profileA, customDir),
+    referencedOriginal,
+    'references resolve through the profile read roots when no managed copy exists',
+  );
+  assert.equal(resolveUploadReference(referenceName, profileA, customDir), referencedOriginal);
+  assert.equal(
+    resolveUploadFile(referenceName, profileB, customDir),
+    null,
+    'isolated profiles never see another profile\'s reference records',
+  );
+  await writeFile(join(profileB.mediaDir, referenceName), 'managed copy');
+  await writeUploadReference(referenceName, referencedOriginal, profileB.mediaDir);
+  assert.equal(
+    resolveUploadFile(referenceName, profileB, customDir),
+    join(profileB.mediaDir, referenceName),
+    'managed copies take precedence over reference records',
+  );
+  await assert.rejects(writeUploadReference(referenceName, 'relative/camera.mov', profileA.mediaDir), /absolute path/);
+  assert.equal(
+    await deleteUploadReference(referenceName, profileA, customDir),
+    1,
+    'deleting a reference removes exactly one registry record',
+  );
+  assert.equal(
+    resolveUploadFile(referenceName, profileA, customDir),
+    null,
+    'a deleted reference stops resolving',
+  );
+  assert.deepEqual(
+    await readFile(referencedOriginal),
+    Buffer.from('original snapshot'),
+    'deleting a reference must never touch the original file',
+  );
 
   const forbiddenProbe = join(fixture, 'must-not-be-created');
   assert.deepEqual(await checkMediaDir(forbiddenProbe, profileA), {

--- a/server/media-dir.ts
+++ b/server/media-dir.ts
@@ -2,9 +2,10 @@
 // The default profile preserves MEDIA_DIR → worktree default → R2 read-through semantics
 // and legacy-copy behavior. Isolated development profiles use only their profile media
 // directory: no legacy fallback, legacy copy, MEDIA_DIR override, or R2 read-through.
-import { createReadStream, existsSync } from 'node:fs';
+import { createReadStream, existsSync, readFileSync } from 'node:fs';
 import { copyFile, mkdir, readdir, rename, stat, unlink, writeFile } from 'node:fs/promises';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 import { basename, isAbsolute, join, resolve } from 'node:path';
 import { getKey, type KeyName } from './keystore.ts';
@@ -62,7 +63,9 @@ export function isCustomUploadDir(profile: RuntimeProfile = runtimeProfile()): b
   return uploadDir(profile) !== profile.mediaDir;
 }
 
-/** Resolve an upload only through the active profile's ordered local read roots. */
+/** Resolve an upload through the active profile's ordered local read roots; a
+ * miss falls back to a read-only reference record (native desktop imports keep
+ * the original file in place instead of copying it into managed storage). */
 export function resolveUploadFile(
   name: string,
   profile: RuntimeProfile = runtimeProfile(),
@@ -73,7 +76,72 @@ export function resolveUploadFile(
     const file = join(d, name);
     if (existsSync(file)) return file;
   }
+  return resolveUploadReference(name, profile, configuredMediaDir);
+}
+
+// ── Read-only references: desktop native imports keep the original in place ──
+
+export function uploadReferencePath(directory: string, name: string): string {
+  return join(directory, '.references', `${name}.json`);
+}
+
+/** Resolve an upload through a reference record written by the desktop native
+ * bridge. Records are written only after validating an absolute original path,
+ * and resolution re-validates: safe name, absolute path, file still present. */
+export function resolveUploadReference(
+  name: string,
+  profile: RuntimeProfile = runtimeProfile(),
+  configuredMediaDir?: string,
+): string | null {
+  if (!isSafeUploadName(name)) return null;
+  for (const directory of uploadReadDirs(profile, configuredMediaDir)) {
+    const record = uploadReferencePath(directory, name);
+    if (!existsSync(record)) continue;
+    try {
+      const stored = JSON.parse(readFileSync(record, 'utf8')) as { path?: unknown };
+      if (typeof stored.path !== 'string' || !isAbsolute(stored.path)) return null;
+      if (!existsSync(stored.path)) return null;
+      return stored.path;
+    } catch {
+      return null;
+    }
+  }
   return null;
+}
+
+/** Persist a read-only reference (safe upload name → absolute original path).
+ * The referenced file is never copied, re-encoded, or deleted by the app. */
+export async function writeUploadReference(
+  name: string,
+  path: string,
+  directory: string = uploadDir(),
+): Promise<void> {
+  if (!isSafeUploadName(name)) throw new Error('unsafe upload reference name');
+  if (!isAbsolute(path)) throw new Error('upload reference must be an absolute path');
+  await mkdir(join(directory, '.references'), { recursive: true });
+  const record = uploadReferencePath(directory, name);
+  const part = `${record}.${randomUUID()}.part`;
+  await writeFile(part, JSON.stringify({ path }), { flag: 'wx' });
+  await rename(part, record);
+}
+
+/** Remove reference records only — the referenced original is never touched. */
+export async function deleteUploadReference(
+  name: string,
+  profile: RuntimeProfile = runtimeProfile(),
+  configuredMediaDir?: string,
+): Promise<number> {
+  if (!isSafeUploadName(name)) return 0;
+  let removed = 0;
+  for (const directory of uploadReadDirs(profile, configuredMediaDir)) {
+    try {
+      await unlink(uploadReferencePath(directory, name));
+      removed += 1;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+  return removed;
 }
 
 export interface ResolvedUploadFile {

--- a/server/media-normalization.ts
+++ b/server/media-normalization.ts
@@ -1,9 +1,9 @@
-import { spawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { realpath, stat, unlink } from 'node:fs/promises';
 import { basename, dirname, extname, join } from 'node:path';
 import {
   h264EncoderAttempts,
+  h264EncoderFallbackReason,
   h264EncodingArgs,
   isHardwareH264Encoder,
   probeEncoderQualityMode,
@@ -16,6 +16,7 @@ import {
   normalizationAbortError,
   throwIfNormalizationAborted,
 } from './media-normalization-admission.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from './media-process.ts';
 export {
   createNormalizeAdmission,
   normalizationAbortError,
@@ -35,6 +36,9 @@ const TARGET_FLOOR_BITRATE_BPS = 1_500_000;
 const REFERENCE_PIXELS = 1920 * 1080;
 const VIDEO_AUDIO_BITRATE = '160k';
 const FFMPEG_TIMEOUT_MS = 60 * 60_000; // long masters
+// Soft cap for "efficient enough" masters: above this size the cost of a full
+// re-encode (VFR→CFR, optimization) dwarfs its benefit, so the source is kept.
+const LARGE_SOURCE_BYTES = 1.5 * 1024 * 1024 * 1024;
 
 
 export function createNormalizeTempPath(
@@ -86,7 +90,7 @@ function run(
 ): Promise<{ stdout: string; stderr: string }> {
   throwIfNormalizationAborted(signal);
   const deferred = Promise.withResolvers<{ stdout: string; stderr: string }>();
-  const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  const child = spawnMediaProcess(cmd, [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
   let stdout = '';
   let stderr = '';
   let settled = false;
@@ -309,6 +313,10 @@ export function normalizeReason(
   optimize: boolean,
 ): string | null {
   if (forceCfr || meta.variableFrameRate) {
+    // Multi-GiB VFR masters (game captures, screen recordings) are accepted
+    // as-is: a full software re-encode of a high-bitrate 2K source costs far
+    // more than the CFR correction earns, and preview proxies handle playback.
+    if (!forceCfr && meta.size > LARGE_SOURCE_BYTES) return null;
     const avg = meta.avgFrameRate?.toFixed(3) ?? 'unknown';
     const nominal = meta.nominalFrameRate?.toFixed(3) ?? 'unknown';
     return `variable frame rate detected (avg ${avg}, nominal ${nominal})`;
@@ -328,7 +336,7 @@ export function normalizeReason(
     if (meta.sourceBitrate > efficient) return 'source bitrate exceeds efficient threshold';
   }
   // Very large files even if "compatible" (e.g. long 1080p high quality) — soft cap ~1.5GB
-  if (meta.size > 1.5 * 1024 * 1024 * 1024) return 'source file larger than 1.5GB';
+  if (meta.size > LARGE_SOURCE_BYTES) return 'source file larger than 1.5GB';
   return null;
 }
 
@@ -368,7 +376,7 @@ async function encodeTranscodedVideo(
         maxBitrate: options.targetBitrate,
         bufferSize: options.targetBitrate * 2,
         softwarePreset: 'veryfast',
-        ...(proxyQuality ? { hardwareQuality: 23 } : {}),
+        ...(proxyQuality ? { hardwareQuality: 23, qualityMode: proxyQuality } : {}),
       }),
       '-profile:v', 'high',
       ...(options.convertToCfr ? ['-fps_mode', 'cfr'] : []),
@@ -381,7 +389,7 @@ async function encodeTranscodedVideo(
       throwIfNormalizationAborted(signal);
       lastError = error;
       if (!isHardwareH264Encoder(encoder)) throw error;
-      console.warn(`[normalize-media] ${encoder} failed; falling back to libx264`);
+      console.warn(`[normalize-media] ${encoder} failed (${h264EncoderFallbackReason(encoder, error)}); falling back to libx264`);
       await unlink(outputPath).catch(() => {});
     }
   }
@@ -401,9 +409,14 @@ export async function encodeNormalized(
   signal?: AbortSignal,
 ): Promise<void> {
   const ffmpeg = ffmpegBin();
+  // Resolve the encoder before building decode args: NVIDIA NVENC requires
+  // `-hwaccel cuda`, not the platform-default d3d11va, or encode fails with
+  // "CreateInputBuffer failed" once the 64x64 probe bug is fixed.
+  const preferred = await resolveH264Encoder(ffmpeg);
+  throwIfNormalizationAborted(signal);
   const commonArgs = [
     '-nostdin', '-hide_banner', '-loglevel', 'error', '-y',
-    ...(await resolveHwDecodeArgs(ffmpeg, undefined)),
+    ...(await resolveHwDecodeArgs(ffmpeg, preferred)),
     '-i', inputPath, '-map', '0:v:0',
     ...(meta.hasAudio ? ['-map', '0:a:0?'] : ['-an']),
   ];

--- a/server/media-process.ts
+++ b/server/media-process.ts
@@ -1,0 +1,67 @@
+import {
+  spawn,
+  type ChildProcess,
+  type ChildProcessWithoutNullStreams,
+  type SpawnOptions,
+  type SpawnOptionsWithStdioTuple,
+  type SpawnOptionsWithoutStdio,
+  type StdioNull,
+  type StdioPipe,
+} from 'node:child_process';
+import { availableParallelism, constants, setPriority } from 'node:os';
+
+/** Cap ffmpeg worker threads so a single encode cannot saturate the whole
+ * machine and starve the editor or other Node/Electron applications. */
+export function ffmpegThreadCount(cores: number = availableParallelism()): number {
+  const override = Number(process.env.OPENCHATCUT_FFMPEG_THREADS);
+  if (Number.isFinite(override) && override >= 1) {
+    return Math.max(1, Math.min(Math.floor(override), Math.max(1, cores)));
+  }
+  return Math.max(1, Math.ceil(cores * 0.75));
+}
+
+/** Global ffmpeg args placed before `-i`; ffprobe accepts them as well. */
+export function ffmpegThreadArgs(cores: number = availableParallelism()): string[] {
+  return ['-threads', String(ffmpegThreadCount(cores))];
+}
+
+/**
+ * Spawn a media tool (ffmpeg/ffprobe) at below-normal OS priority so import,
+ * normalization, preview derivatives and export never compete with the user's
+ * foreground applications for CPU time. Best-effort on every platform.
+ */
+export function spawnMediaProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithoutStdio,
+): ChildProcessWithoutNullStreams;
+export function spawnMediaProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdioTuple<StdioNull, StdioPipe, StdioPipe>,
+): ChildProcessWithoutNullStreams;
+export function spawnMediaProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptionsWithStdioTuple<StdioNull, StdioNull, StdioPipe>,
+): ChildProcessWithoutNullStreams;
+export function spawnMediaProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptions,
+): ChildProcess;
+export function spawnMediaProcess(
+  command: string,
+  args: string[],
+  options: SpawnOptions = {},
+): ChildProcess {
+  const child = spawn(command, args, options);
+  if (child.pid !== undefined) {
+    try {
+      setPriority(child.pid, constants.priority.PRIORITY_BELOW_NORMAL);
+    } catch {
+      // Priority adjustment is best-effort; the child still runs.
+    }
+  }
+  return child;
+}

--- a/server/plugins/export-runtime.ts
+++ b/server/plugins/export-runtime.ts
@@ -1,7 +1,7 @@
-import { spawn } from 'node:child_process';
 import { readdir, stat, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { ffmpegBin } from '../media-binaries.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../media-process.ts';
 import { isSafeUploadName } from '../media-dir.ts';
 import {
   h264EncoderAttempts,
@@ -183,7 +183,7 @@ export async function withExportPermit<T>(
 
 function runFfmpeg(args: string[], signal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(ffmpegBin(), args, { stdio: ['ignore', 'ignore', 'pipe'], signal });
+    const child = spawnMediaProcess(ffmpegBin(), [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'], signal });
     let stderr = '';
     let settled = false;
     let timeoutError: Error | undefined;

--- a/server/plugins/extract-audio.ts
+++ b/server/plugins/extract-audio.ts
@@ -12,6 +12,7 @@ import { rename, stat, unlink } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { isSafeUploadName, resolveUploadFile, uploadDir } from '../media-dir.ts';
 import { ffmpegBin, ffprobeBin } from '../media-binaries.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../media-process.ts';
 
 const MAX_JSON = 8 * 1024;
 const ASR_BITRATE = '64k';
@@ -99,7 +100,7 @@ function probeHasAudio(inputPath: string): Promise<boolean> {
 
 function runFfmpeg(args: string[], timeoutMs: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(ffmpegBin(), args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawnMediaProcess(ffmpegBin(), [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');

--- a/server/plugins/extract-frames.ts
+++ b/server/plugins/extract-frames.ts
@@ -12,6 +12,7 @@ import { isSafeUploadName, resolveUploadFile } from '../media-dir.ts';
 import { formatTimeLabel, tileContactSheet } from '../frame-grid.ts';
 import { ffmpegBin, ffprobeBin } from '../media-binaries.ts';
 import { resolveHwDecodeArgs } from '../media-acceleration.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../media-process.ts';
 
 const MAX_JSON = 32 * 1024;
 const MAX_SAMPLES = 20;
@@ -57,7 +58,7 @@ function uploadNameFromSrc(src: string): string | null {
 
 function run(cmd: string, args: string[], timeoutMs: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawnMediaProcess(cmd, [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
@@ -122,8 +123,8 @@ function sceneChangeTimesMs(input: string, fromMs: number, toMs: number): Promis
     const hwDecode = await resolveHwDecodeArgs(ffmpegBin(), undefined);
     return new Promise((resolve) => {
       const times: number[] = [];
-    const child = spawn(ffmpegBin(), [
-      '-nostdin', '-hide_banner',
+    const child = spawnMediaProcess(ffmpegBin(), [
+      '-nostdin', '-hide_banner', ...ffmpegThreadArgs(),
       ...hwDecode,
       '-ss', String(Math.max(0, fromMs) / 1000),
       '-t', String(Math.max(0, toMs - fromMs) / 1000),

--- a/server/plugins/isolate-voice.ts
+++ b/server/plugins/isolate-voice.ts
@@ -7,12 +7,12 @@
 // strength maps to afftdn nr (noise reduction dB): 0 → light, 100 → aggressive.
 import type { Plugin } from 'vite';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { spawn } from 'node:child_process';
 import { constants, existsSync } from 'node:fs';
 import { copyFile, stat, unlink } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { basename, join } from 'node:path';
 import { isSafeUploadName, resolveUploadFile, uploadDir } from '../media-dir.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../media-process.ts';
 
 const MAX_JSON = 8 * 1024;
 const FFMPEG_TIMEOUT_MS = 30 * 60_000;
@@ -83,7 +83,7 @@ export function voiceIsolationArtifactName(
 
 function runFfmpeg(args: string[], timeoutMs: number): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawnMediaProcess('ffmpeg', [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');

--- a/server/plugins/media-preview.ts
+++ b/server/plugins/media-preview.ts
@@ -1,6 +1,5 @@
 import type { Plugin } from 'vite';
 import type { IncomingMessage, ServerResponse } from 'node:http';
-import { spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, readdir, rename, rm, stat, unlink, utimes, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
@@ -9,6 +8,7 @@ import { extname, join } from 'node:path';
 import { isSafeUploadName, resolveUploadFile, serveDiskFile, uploadDir, uploadReadDirs } from '../media-dir.ts';
 import { ffmpegBin, ffprobeBin } from '../media-binaries.ts';
 import { resolveHwDecodeArgs } from '../media-acceleration.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../media-process.ts';
 import { derivativeQueue, type DerivativeWork } from '../derivative-queue.ts';
 import { handlePreviewProxy, handlePreviewProxyFile, runPreviewProcess } from '../preview-proxy.ts';
 import { capturePreviewGenerationEpoch, invalidatePreviewGenerations, isPreviewGenerationCurrent } from '../preview-cache-epoch.ts';
@@ -149,7 +149,7 @@ function abortError(): Error {
 
 function run(cmd: string, args: string[], signal: AbortSignal, timeoutMs = FFMPEG_TIMEOUT_MS): Promise<void> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawnMediaProcess(cmd, [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     let timedOut = false;
     const abort = () => child.kill('SIGKILL');
@@ -228,8 +228,9 @@ function computePeaks(file: string, durationMs: number, signal: AbortSignal): Pr
     binMax: 0, inBin: 0, carry: null,
   };
   return new Promise((resolve, reject) => {
-    const child = spawn(ffmpegBin(), [
+    const child = spawnMediaProcess(ffmpegBin(), [
       '-nostdin', '-hide_banner', '-loglevel', 'error',
+      ...ffmpegThreadArgs(),
       '-i', file, '-vn', '-ac', '1', '-ar', String(PCM_RATE), '-f', 's16le', '-',
     ], { stdio: ['ignore', 'pipe', 'pipe'] });
     let stderr = '';

--- a/server/plugins/normalize-media.ts
+++ b/server/plugins/normalize-media.ts
@@ -2,7 +2,7 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { Plugin } from 'vite';
 import { extname } from 'node:path';
-import { isSafeUploadName, resolveUploadFile, uploadDir } from '../media-dir.ts';
+import { isSafeUploadName, resolveUploadFile, resolveUploadReference, uploadDir } from '../media-dir.ts';
 import {
   NormalizeAdmissionFullError,
   type NormalizeAdmission,
@@ -219,6 +219,18 @@ async function handleNormalizeRequest(
   const inputPath = resolveUploadFile(name);
   if (!inputPath) {
     sendJson(res, 404, { error: `media not found: ${name}` });
+    return;
+  }
+  // Referenced sources live outside managed storage and are read-only:
+  // normalization publishes over the input path, which would replace (and
+  // for force requests) destroy the user's original file — refuse instead.
+  if (resolveUploadReference(name)) {
+    sendJson(res, 200, {
+      ok: true,
+      path: src,
+      normalized: false,
+      reason: 'referenced source is read-only (native desktop import); not normalized',
+    });
     return;
   }
   const extension = extname(name).toLowerCase();

--- a/server/plugins/normalize-media.verify.ts
+++ b/server/plugins/normalize-media.verify.ts
@@ -7,6 +7,7 @@ import { createServer, type ViteDevServer } from 'vite';
 import { ffmpegBin, ffprobeBin } from '../media-binaries.ts';
 import { DEFAULT_UPLOAD_MAX_BYTES } from '../r2.ts';
 import { seedKeystore } from '../keystore.ts';
+import { writeUploadReference } from '../media-dir.ts';
 import { maxUploadBytes } from './upload-routes.ts';
 import { uploadMultipartPlugin } from './upload-multipart.ts';
 import {
@@ -371,6 +372,26 @@ try {
   assert.equal(accepted.normalized, false, 'compatible sources are not optimized merely for exceeding 1920px');
   assert.equal(accepted.path, '/media/uploads/compatible-large-frame.mp4');
   assert.deepEqual([accepted.width, accepted.height], [2048, 1152]);
+
+  const referencedSourcePath = join(testDir, 'referenced-master.mov');
+  await copyFile(vfrSourcePath, referencedSourcePath);
+  await writeUploadReference('referenced-master.mov', referencedSourcePath, testDir);
+  const referencedResponse = await postNormalize(origin, 'referenced-master.mov', { force: true });
+  const referencedText = await referencedResponse.text();
+  assert.equal(referencedResponse.status, 200, referencedText);
+  const referenced = JSON.parse(referencedText) as {
+    normalized: boolean;
+    path: string;
+    reason: string;
+  };
+  assert.equal(
+    referenced.normalized,
+    false,
+    'referenced sources are read-only and must never be replaced in place',
+  );
+  assert.equal(referenced.path, '/media/uploads/referenced-master.mov');
+  assert.match(referenced.reason, /read-only/);
+  await access(referencedSourcePath);
 
   const audioOnlyResponse = await fetch(`${origin}/api/normalize-media`, {
     method: 'POST',

--- a/server/plugins/upload-multipart.ts
+++ b/server/plugins/upload-multipart.ts
@@ -123,17 +123,40 @@ async function loadMeta(uploadId: string): Promise<MultipartMeta | null> {
     return null;
   }
 }
+const metaWriteQueues = new Map<string, Promise<void>>();
+function enqueueMetaWrite(uploadId: string, task: () => Promise<void>): Promise<void> {
+  const previous = metaWriteQueues.get(uploadId) ?? Promise.resolve();
+  const next = previous.then(task, task);
+  const tail = next.catch(() => {});
+  metaWriteQueues.set(uploadId, tail);
+  return next;
+}
+async function writeMeta(meta: MultipartMeta, tmp: string): Promise<void> {
+  await writeFile(tmp, JSON.stringify(meta), 'utf8');
+  let attempt = 0;
+  for (;;) {
+    try {
+      await rename(tmp, join(sessionDir(meta.uploadId), 'meta.json'));
+      return;
+    } catch (error) {
+      attempt += 1;
+      if (attempt >= 4 || !(error instanceof Error) || (error as NodeJS.ErrnoException).code !== 'EPERM') throw error;
+      await new Promise((resolve) => setTimeout(resolve, 25 * attempt));
+    }
+  }
+}
 async function saveMeta(meta: MultipartMeta): Promise<void> {
   const dir = sessionDir(meta.uploadId);
   await mkdir(dir, { recursive: true });
   const tmp = join(dir, `.meta-${randomUUID()}.tmp`);
-  try {
-    await writeFile(tmp, JSON.stringify(meta), 'utf8');
-    await rename(tmp, join(dir, 'meta.json'));
-  } catch (error) {
-    await unlink(tmp).catch(() => {});
-    throw error;
-  }
+  return enqueueMetaWrite(meta.uploadId, async () => {
+    try {
+      await writeMeta(meta, tmp);
+    } catch (error) {
+      await unlink(tmp).catch(() => {});
+      throw error;
+    }
+  });
 }
 function partPath(uploadId: string, part: number): string {
   return join(sessionDir(uploadId), `part-${String(part).padStart(5, '0')}`);

--- a/server/plugins/upload-route-storage.ts
+++ b/server/plugins/upload-route-storage.ts
@@ -13,7 +13,7 @@ import {
   deleteUploadObject, putUploadFile, r2Config, UploadTooLargeError,
 } from '../r2.ts';
 import {
-  enqueueUploadMutation, isSafeUploadName, uploadReadDirs,
+  deleteUploadReference, enqueueUploadMutation, isSafeUploadName, uploadReadDirs,
 } from '../media-dir.ts';
 import { deleteMediaPreviewDerivatives } from './media-preview.ts';
 import { contentLengthOf, sendError, sendJson } from './upload-route-http.ts';
@@ -80,6 +80,13 @@ async function handleDeleteUpload(req: IncomingMessage, res: ServerResponse): Pr
         } catch (error) {
           failures.push(error);
         }
+      }
+      // Referenced media never materialize a managed copy; only the record is
+      // removed (the user's original file stays untouched).
+      try {
+        await deleteUploadReference(name);
+      } catch (error) {
+        failures.push(error);
       }
       try {
         r2Removed = await deleteUploadObject(name, rollbackToken);

--- a/server/plugins/upload-routes.ts
+++ b/server/plugins/upload-routes.ts
@@ -7,8 +7,8 @@ import {
   presignGetUpload, presignPutUpload, r2Config, r2PresignEnabled, UploadTooLargeError,
 } from '../r2.ts';
 import {
-  isSafeUploadName, resolveOrHydrateUploadFile, serveDiskFile, syncLegacyUploads,
-  uploadReadDirs,
+  isSafeUploadName, resolveOrHydrateUploadFile, resolveUploadReference, serveDiskFile,
+  syncLegacyUploads, uploadReadDirs,
 } from '../media-dir.ts';
 import { isIsolatedDevProfile } from '../runtime-profile.ts';
 import { sha256File } from '../../shared/node-content-hash.ts';
@@ -132,7 +132,9 @@ async function handleHydrate(
       return;
     }
     if (!resolved.cached) logger.info(`[upload/hydrate] ${name} (${resolved.bytes} bytes)`);
-    const contentHash = await sha256File(resolved.file);
+    // Referenced originals are never hashed: re-reading a multi-GiB master on
+    // every hydrate would reintroduce the import cost the reference removed.
+    const contentHash = resolveUploadReference(name) ? '' : await sha256File(resolved.file);
     sendJson(res, 200, {
       ok: true,
       path: `/media/uploads/${name}`,

--- a/server/plugins/video-media.ts
+++ b/server/plugins/video-media.ts
@@ -9,6 +9,7 @@ import { extname, join } from 'node:path';
 
 import { ffmpegBin } from '../media-binaries.ts';
 import { resolveHwDecodeArgs } from '../media-acceleration.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from '../media-process.ts';
 import { isSafeUploadName, mimeFor, resolveUploadFile, uploadDir } from '../media-dir.ts';
 import type { VideoRequest } from './video-validation.ts';
 import { presignGetUpload, putUploadFile } from '../r2.ts';
@@ -71,7 +72,7 @@ const derivativeJobs = new Map<string, Promise<string>>();
 
 function runSliceFfmpeg(args: string[]): Promise<void> {
   return new Promise((resolvePromise, reject) => {
-    const child = spawn(ffmpegBin(), args, { stdio: ['ignore', 'ignore', 'pipe'] });
+    const child = spawnMediaProcess(ffmpegBin(), [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
     let stderr = '';
     const timer = setTimeout(() => child.kill('SIGKILL'), 5 * 60_000);
     child.stderr.on('data', (chunk) => { stderr = (stderr + String(chunk)).slice(-4_000); });

--- a/server/preview-proxy.ts
+++ b/server/preview-proxy.ts
@@ -1,8 +1,8 @@
-import { spawn } from 'node:child_process';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { existsSync } from 'node:fs';
 import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { ffmpegBin, ffprobeBin } from './media-binaries.ts';
+import { ffmpegThreadArgs, spawnMediaProcess } from './media-process.ts';
 
 const PROBE_TIMEOUT_MS = 60_000;
 const PROXY_TIMEOUT_MS = 30 * 60_000;
@@ -40,7 +40,7 @@ export function runPreviewProcess(
   timeoutMs: number,
 ): Promise<PreviewProcessOutput> {
   return new Promise((resolve, reject) => {
-    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawnMediaProcess(command, [...ffmpegThreadArgs(), ...args], { stdio: ['ignore', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     let timedOut = false;

--- a/src/editor/TimelineComposition.tsx
+++ b/src/editor/TimelineComposition.tsx
@@ -148,11 +148,12 @@ function TimelineContent({ state, project, transparent, browserRenderer = false,
     return 10 ** ((config.audioRouting?.duckDepthDb ?? -12) / 20);
   };
   const fit: AspectFit = state.fit ?? 'contain';
-  // Preview mounts each clip 2s in advance (freezes first frame + transparency): video elements seek/decode in advance, GL compiles in advance,
+  // Preview mounts each clip 1s in advance (freezes first frame + transparency): video elements seek/decode in advance, GL compiles in advance,
   // Eliminate the "last frame stuck" caused by cold start of three media elements at the starting point of the cut point/transition window in the same frame.
   // Headless export renders deterministically frame by frame, preheating will only slow down the export, set to 0.
+  // A 2s premount window multiplied the decoding cost of every 2K/4K clip; 1s still covers element warm-up.
   const environment = getRemotionEnvironment();
-  const premountFrames = environment.isRendering ? 0 : Math.round(state.fps * 2);
+  const premountFrames = environment.isRendering ? 0 : Math.round(state.fps * 1);
   const videoAudioGroups = continuousVideoAudioGroups(ordered, state.transitions);
   const groupedVideoIds = new Set(videoAudioGroups.flatMap((group) => group.map((item) => item.id)));
 

--- a/src/media/qualityPolicy.ts
+++ b/src/media/qualityPolicy.ts
@@ -44,9 +44,10 @@ function readPreviewSourceInitial(): PreviewSourceMode {
     const raw = localStorage.getItem(PREVIEW_SOURCE_KEY);
     if (raw === 'auto' || raw === 'original' || raw === 'proxy') return raw;
   } catch { /* private mode */ }
-  // Default to original: do not auto-generate preview proxies in the background.
-  // Users can opt in per session via the preview-quality control (proxy / auto).
-  return 'original';
+  // Default to auto: high-resolution (>1080p) sources get a lightweight
+  // preview proxy in the background, which is the main lever against 2K/4K
+  // WebCodecs preview stalls. 'original' remains available per session.
+  return 'auto';
 }
 
 function emit(): void {


### PR DESCRIPTION
# OpenChatCut 性能问题修复更新报告

> 更新日期：2026-08-20（对应 `etc/check.md` 审计报告）
> 范围：P1 素材导入（引用导入，移除拷贝与 SHA-256）、P2 预览策略、P3 编码器探针链（决定性根因 + 连带隐藏 bug）、P4 ffmpeg 进程优先级与线程数
> 方法：按审计建议逐项修复 + 本机（RTX 5060 Ti / Windows / 24 核）实测验证 + verify 回归

---

## 0. 修复总览

| # | 问题（审计结论） | 修复结果 | 状态 |
|---|------|:---:|:---:|
| P1 | 导入 = 物理拷贝 + 全文件 SHA-256 + VFR 整片重编码 | 桌面文件选择导入改为**引用导入**（不拷贝、不哈希、只读引用原路径）；大文件跳过 VFR 重编码；残余拷贝路径（目录监控）大文件跳过哈希 | ✅ 已完成 |
| P2 | 预览默认 original 原片 + 2s 预挂载，代理机制默认关闭 | 预览源默认 `auto`（2K 素材自动生成 1080p 代理）；预挂载窗口 2s→1s；`hardwareAcceleration` 因位于 node_modules 无法修改（见 3.3） | ✅ 已完成（部分） |
| P3 | 64×64 探针在 Blackwell NVENC 必然失败 → 全链路静默降级 libx264 | 探针 64→**160**；修复探针放行后暴露的两个隐藏 bug（ffmpeg-static 老 SDK 参数不兼容、d3d11va 解码与 NVENC 编码冲突）；降级不再静默 | ✅ 已完成 |
| P4 | 全部 ffmpeg NORMAL 优先级、无线程上限，吃满 24 核 | 新增 `server/media-process.ts`：`PRIORITY_BELOW_NORMAL` + `-threads ceil(核数×0.75)`（可 `OPENCHATCUT_FFMPEG_THREADS` 覆盖），接入全部 10 处 ffmpeg/ffprobe 调用点 | ✅ 已完成 |

新增文件：`server/media-process.ts`；修改文件 23 个（含 5 个 verify）。

---

## 1. P3 — 导出极慢：编码器探针链（决定性根因，最高优先）

### 1.1 修复内容

| 位置 | 修改 |
|---|---|
| `server/media-acceleration.ts:36` | `PROBE_FRAME_SIZE` 64 → **160**（Blackwell NVENC 最小 >128，160×160 本机实测通过；128×128 仍失败） |
| `server/media-acceleration.ts` `resolveH264Encoder` | 硬件候选全部失败降级 libx264 时输出 `console.warn`（含原因），不再静默 |
| `server/media-normalization.ts` | 归一化降级日志附带 `h264EncoderFallbackReason` |

### 1.2 连带修复（探针放行后暴露的两个隐藏 bug，否则 NVENC 仍会运行时失败）

探针 64→160 后 NVENC 首次被选中，随即发现并修复：

**Bug A — ffmpeg-static 6.1.1（gyan.dev essentials）使用老 NVENC SDK，不识别现代参数**

- 本机实测：`node_modules/ffmpeg-static/ffmpeg.exe` 的 `-h encoder=h264_nvenc` 输出 **无 `rc_mode`、无 `global_quality`，仅有 `constqp`/`qp`**；传 `-rc_mode CQP -global_quality 23` 直接报 `Unrecognized option 'rc_mode'` 并失败。
- 修复：`server/media-acceleration.ts` `probeEncoderQualityMode` 返回值从布尔改为 **`H264QualityMode = 'cqp' | 'legacy-qp' | false`**；`H264EncodingOptions` 新增 `qualityMode`；nvenc 分支按探测结果发射参数：
  - 现代 SDK（系统 ffmpeg）：`-rc_mode CQP -global_quality 23`
  - 老 SDK（ffmpeg-static）：`-rc constqp -qp 23`（本机实测 exit 0）
- `media-normalization.ts` 编码时透传 `qualityMode`。

**Bug B — `-hwaccel d3d11va` 解码与 `h264_nvenc` 编码冲突**

- 归一化管线以 `resolveHwDecodeArgs(ffmpeg, undefined)` 构建解码参数（win32 平台默认 `d3d11va`），与 NVENC 编码组合时本机实测报 `CreateInputBuffer failed: invalid param (8): EncodeAPI Internal Error`（exit -22）；改用 `-hwaccel cuda` 则 exit 0。
- 修复：`server/media-normalization.ts` `encodeNormalized` 先解析选定编码器（`resolveH264Encoder`），再以**编码器感知**的解码参数构建 `commonArgs`：NVENC→`cuda`、QSV→`qsv`、AMF→`d3d11va`、libx264→无（软解，与既有 verify 断言一致）。

### 1.3 修复后验证（本机）

- `normalize-media.verify.ts`：13 处 `h264_nvenc failed ... falling back to libx264` 全部消失，归一化编码全部由 NVENC 完成，仅探针级小尺寸素材例外。
- `media-acceleration.verify.ts`：新增 nvenc `cqp` / `legacy-qp` 参数断言，通过。

---

## 2. P4 — 系统卡顿：ffmpeg 优先级与线程数

### 2.1 新增 `server/media-process.ts`（统一助手）

| 导出 | 行为 |
|---|---|
| `ffmpegThreadCount()` | `Math.ceil(availableParallelism() × 0.75)`（24 核 → 18 线程）；`OPENCHATCUT_FFMPEG_THREADS` 环境变量可覆盖 |
| `ffmpegThreadArgs()` | `['-threads', N]`，置于参数最前（ffprobe 同样接受） |
| `spawnMediaProcess()` | `spawn` + `setPriority(pid, PRIORITY_BELOW_NORMAL)`（与 `desktop/native-worker-priority.ts` 的 whisper worker 一致，失败时静默降级 NORMAL）；重载保留 `ChildProcessWithoutNullStreams` 类型（`video-media.ts` 依赖非可选 `stderr`） |

### 2.2 接入点（10 处）

| 文件 | 调用点 |
|---|---|
| `server/media-normalization.ts` | `run()`（归一化编码/探针） |
| `server/plugins/extract-audio.ts` | `runFfmpeg`（ASR 音频提取） |
| `server/plugins/extract-frames.ts` | `run()`、`sceneChangeTimesMs`（抽帧/场景检测） |
| `server/plugins/media-preview.ts` | `run()`、`computePeaks`（filmstrip/waveform） |
| `server/preview-proxy.ts` | `runPreviewProcess`（预览代理转码） |
| `server/plugins/export-runtime.ts` | `runFfmpeg`（导出 retime 二次转码） |
| `desktop/local-media-import.ts` | `run()`（alpha MOV 代理转码） |
| `server/plugins/video-media.ts` | `runSliceFfmpeg` |
| `server/plugins/isolate-voice.ts` | `runFfmpeg` |
| `server/frame-grid.ts` | `run()` |

`-threads` 由各调用点统一经 `ffmpegThreadArgs()` 前置注入（与既有 ffmpeg `-threads` 惯例一致，置于 `-i` 之前）；ffprobe 调用同样受益（`extract-frames`、`probeDurationMs` 等）。

---

## 3. P2 — 预览解码与代理策略

| 位置 | 修改 |
|---|---|
| `src/media/qualityPolicy.ts` | 预览源默认 `'original'` → **`'auto'`**：均衡模式下 2K（>1920×1080）素材自动触发 `server/preview-proxy.ts` 的 1080p 代理生成（libx264 veryfast CRF23），不再全分辨率逐帧解码 |
| `src/editor/TimelineComposition.tsx` | 预挂载窗口 **2s → 1s**（`Math.round(state.fps * 1)`），降低 2K 多轨/转场附近多路并发解码压力；导出渲染预挂载仍为 0 |

### 3.3 未能修复项（node_modules 边界）

- `hardwareAcceleration`：mediabunny（`@remotion/media` 依赖）的 WebCodecs 解码器固定 `no-preference`，该选项位于 node_modules 内且仓库无 vendor 覆盖，无法从本仓库修改；已由预览代理策略兜底（1080p 软解成本远低于 2K 全分辨率逐帧 seek）。

---

## 4. P1 — 素材导入：引用导入（移除拷贝与 SHA-256）

### 4.1 桌面文件选择导入 → 引用导入（核心）

**`desktop/local-media-import.ts` 新增 `importLocalMediaReference`**，`desktop/main.ts` 的 IPC 桥（`openchatcut:import-local-media`）改用之：

- 不再 `copyFile`（原 `COPYFILE_FICLONE` 拷贝，NTFS 上退化为整文件拷贝）；
- 不再全文件 SHA-256（原 `sha256File` 第二遍全量读盘）；
- 仅向受管目录写入**引用记录** `<uploadDir>/.references/<storedName>.json` = `{"path": "<原文件绝对路径>"}`；
- 返回 `{ src: '/media/uploads/<storedName>', storedName, contentHash: '' }`。

### 4.2 服务端引用注册表（`server/media-dir.ts`）

| 函数 | 职责 |
|---|---|
| `uploadReferencePath(directory, name)` | `.references/<name>.json` 记录路径 |
| `writeUploadReference(name, path)` | 写入记录；校验 `isSafeUploadName` + 绝对路径，`.part` + rename 原子落盘 |
| `resolveUploadReference(name)` | 按 `uploadReadDirs` 逐目录查记录；读取时复验安全名、绝对路径、文件仍存在，任一失败返回 null |
| `deleteUploadReference(name)` | 仅删除记录（**绝不动原文件**），返回删除数 |
| `resolveUploadFile` | 目录内文件未命中时回退引用解析；**托管副本优先于引用** |

安全边界：渲染层永远只见 `/media/uploads/<uuid>`；任意磁盘路径只存在于服务端写入的记录中（IPC 桥验证过绝对路径与文件名，且注册表位于应用受管目录，`isSafeUploadName` 阻止一切路径伪造）。

### 4.3 生命周期与管线适配

| 环节 | 行为 |
|---|---|
| 服务（`serveDiskFile`/`resolveOrHydrateUploadFile`） | 引用经 `resolveUploadFile` 命中后直接流式读取原文件，Range/206 不受影响 |
| **删除**（`upload-route-storage.ts` `handleDeleteUpload`） | 只移除引用记录，**用户原文件永不删除**；预览衍生物按名字清理（衍生文件在受管目录，不受影响） |
| **归一化**（`normalize-media.ts`） | 引用源一律拒绝：返回 `{ normalized: false, reason: 'referenced source is read-only …' }`。**必须**——`publishSamePath` 会原地替换原文件，`force` 请求亦然，否则将销毁用户原片 |
| hydrate（`upload-routes.ts`） | 引用源跳过 `sha256File`，返回 `contentHash: ''`（避免每次查询重读多 GB 原片） |
| alpha MOV 代理（`createTransparentMovProxy`） | 输入改经 `resolveUploadFile` 解析，引用 MOV 可正常生成代理；代理输出仍在受管目录 |
| R2 | 引用不镜像 R2；`syncUploadDirectories` 跳过 `.references`（记录含机器相关绝对路径，不应迁移） |
| 目录监控导入（`directory-watch-import.ts`） | **保持拷贝 + 哈希**：该特性要求文件落在受管目录（pinned-dir realpath 校验、fingerprint 变更检测、knownHashes 去重均依赖），与引用语义冲突，不在本次改动范围 |

### 4.4 大文件策略（残余拷贝路径 + 归一化）

- `desktop/local-media-import.ts`：目录监控等仍走 `importLocalMedia` 的路径，**>1.5GiB 跳过全文件 SHA-256**（`contentHash: ''`，去重停用）。
- `server/media-normalization.ts:41`：`LARGE_SOURCE_BYTES = 1.5GiB`；`normalizeReason` 对 **VFR 且 >1.5GiB** 的源返回 null（接受原片、跳过整片重编码）——2K/60fps/88Mbps 游戏录屏的 VFR→CFR 收益/成本比极差；显式 `force`/`forceCfr` 仍生效。

---

## 5. 验证

### 5.1 静态检查

- `npm run lint`（oxlint）：通过
- `npx tsc -b`：通过

### 5.2 verify 脚本（全部通过）

| 脚本 | 覆盖 |
|---|---|
| `server/media-acceleration.verify.ts` | 探针尺寸、nvenc cqp/legacy-qp 参数分支 |
| `server/media-normalization.verify.ts` | 归一化全流程（此前 13 处 NVENC 失败日志已消除） |
| `server/plugins/normalize-media.verify.ts` | **新增**：引用源 `force` 也不被原地替换（原文件存活断言） |
| `server/plugins/export-runtime.verify.ts` | retime 转码（线程/优先级接入后） |
| `server/plugins/extract-audio.verify.ts` / `extract-frames.verify.ts` / `isolate-voice.verify.ts` / `video.verify.ts` | 各 ffmpeg 调用点接入后回归 |
| `src/media/qualityPolicy.verify.ts` / `previewMedia.verify.ts` / `remotion/performance.verify.mjs` | P2 策略 |
| `desktop/local-media-import.verify.ts` | **新增**：引用导入不产生托管副本、不哈希、删除不动原文件 |
| `server/media-dir-profile.verify.ts` | **新增**：引用注册表（profile 隔离、托管副本优先、相对路径拒绝、删除语义） |
| `server/plugins/upload-routes.verify.ts` / `src/media/desktop-local-import.verify.ts` | 删除流程与渲染层桥接回归 |

### 5.3 本机实测结论

- 探针 160×160：NVENC 通过（128×128 仍失败，符合 Blackwell 规格）。
- 引用导入：3.7GB 素材导入 = 一次 stat + 一次写 JSON 记录，零拷贝零哈希。
- 归一化：2K 素材由 libx264 veryfast（全核）改为 h264_nvenc（`-rc constqp -qp` + `-hwaccel cuda`）。

---

## 6. 已知限制与未做事项

1. **目录监控导入**保留拷贝 + 哈希（特性模型要求受管副本；大文件已跳过哈希）。
2. **mediabunny 硬解**无法从本仓库控制（node_modules），由 `auto` 代理策略兜底。
3. **引用原文件被用户移走/删除**：解析返回 null → 媒体 404（记录仍存在，可在原路径恢复；如需彻底清除可删除素材）。
4. `desktop/directory-watch-import.verify.ts` 在 Windows 上失败属**既有问题**（mock 使用 POSIX 路径 `/uploads`，`resolve()` 在 win32 下生成 `D:\uploads` 导致 Set 差异），基线同样失败，与本次改动无关；CI（Linux）不受影响。
5. 引用导入的归一化拒绝意味着 2K 引用素材保持原规格（无 VFR→CFR 修正）；若未来需要，应改为"写入受管目录的新文件 + 切换 src"而非原地替换。

---

## 7. 变更文件清单

| 文件 | 变更 |
|---|---|
| `server/media-process.ts` | **新增**：线程数 + BELOW_NORMAL 优先级统一助手 |
| `server/media-acceleration.ts` | P3：探针 160、降级原因日志、`H264QualityMode`、legacy-qp 分支 |
| `server/media-normalization.ts` | P3：编码器感知 hwaccel、qualityMode 透传；P4：线程/优先级；P1：`LARGE_SOURCE_BYTES` VFR 跳过 |
| `server/media-dir.ts` | P1：引用注册表（写/读/删）与 `resolveUploadFile` 回退 |
| `server/plugins/normalize-media.ts` | P1：引用源拒绝归一化 |
| `server/plugins/upload-route-storage.ts` | P1：删除时清理引用记录 |
| `server/plugins/upload-routes.ts` | P1：hydrate 跳过引用哈希 |
| `desktop/local-media-import.ts` | P1：`importLocalMediaReference`、代理输入解析；P4：线程/优先级 |
| `desktop/main.ts` | P1：IPC 桥改用引用导入 |
| `server/plugins/{extract-audio,extract-frames,media-preview,export-runtime,video-media,isolate-voice}.ts`、`server/preview-proxy.ts`、`server/frame-grid.ts` | P4：接入 `spawnMediaProcess` + `ffmpegThreadArgs` |
| `src/media/qualityPolicy.ts` | P2：预览源默认 `auto` |
| `src/editor/TimelineComposition.tsx` | P2：预挂载 2s→1s |
| 5 个 verify 文件 | 新增/更新断言（见 5.2） |