### PR TITLE
fix(asr): resolve native models from the shared catalog

### DIFF
--- a/desktop/native-asr-utils.ts
+++ b/desktop/native-asr-utils.ts
@@ -1,8 +1,21 @@
 // Pure helpers shared between the native-ASR worker and its verification.
 import type { DesktopAsrChunk } from '../shared/desktop-inference.ts';
 import { ASR_INFERENCE_CONTRACT } from '../shared/asr-inference-contract.ts';
+import { ASR_MODELS } from '../shared/asr-models.ts';
 
 export const NATIVE_ASR_SAMPLE_RATE = ASR_INFERENCE_CONTRACT.sampleRate;
+
+// Preserve the desktop-native filenames supported before GGML companions were
+// recorded in the shared catalog. New companions should come from the catalog.
+const LEGACY_GGML_MODEL_FILES: Readonly<Record<string, string>> = {
+  'Xenova/whisper-small': 'ggml-small-q5_1.bin',
+  'Xenova/whisper-medium': 'ggml-medium-q5_1.bin',
+};
+
+export function nativeGgmlFileName(modelId: string): string | undefined {
+  return ASR_MODELS.find((model) => model.modelId === modelId)?.ggmlFile?.fileName
+    ?? LEGACY_GGML_MODEL_FILES[modelId];
+}
 
 export interface WhisperWordToken {
   readonly text?: string;

--- a/desktop/native-asr-worker.ts
+++ b/desktop/native-asr-worker.ts
@@ -23,6 +23,7 @@ import {
 import { ASR_INFERENCE_CONTRACT } from '../shared/asr-inference-contract.ts';
 import { NativeAsrWorkerLifecycle } from './native-asr-worker-lifecycle.ts';
 import {
+  nativeGgmlFileName,
   whisperLanguage,
   whisperTokensToChunks,
   whisperWordsToChunks,
@@ -40,14 +41,6 @@ interface NativeWorkerData {
   readonly whisperCliPath: string;
   readonly platform: NodeJS.Platform;
 }
-
-// ONNX modelId (browser catalog) -> GGML model file for the desktop engine.
-const GGML_MODELS: Record<string, { fileName: string }> = {
-  'Xenova/whisper-tiny': { fileName: 'ggml-tiny-q5_1.bin' },
-  'onnx-community/whisper-base_timestamped': { fileName: 'ggml-base-q5_1.bin' },
-  'Xenova/whisper-small': { fileName: 'ggml-small-q5_1.bin' },
-  'Xenova/whisper-medium': { fileName: 'ggml-medium-q5_1.bin' },
-};
 
 const SERVER_READY_TIMEOUT_MS = 20_000;
 
@@ -339,9 +332,9 @@ async function transcribeWithEngine(
 }
 
 function ggmlPathFor(modelId: string): string | null {
-  const spec = GGML_MODELS[modelId];
-  if (!spec) return null;
-  const path = join(requireRuntime().cacheDir, 'ggml', spec.fileName);
+  const fileName = nativeGgmlFileName(modelId);
+  if (!fileName) return null;
+  const path = join(requireRuntime().cacheDir, 'ggml', fileName);
   return existsSync(path) ? path : null;
 }
 

--- a/desktop/native-asr-worker.verify.ts
+++ b/desktop/native-asr-worker.verify.ts
@@ -1,5 +1,28 @@
 import assert from 'node:assert/strict';
-import { whisperTokensToChunks, whisperWordsToChunks } from './native-asr-utils';
+import {
+  nativeGgmlFileName,
+  whisperTokensToChunks,
+  whisperWordsToChunks,
+} from './native-asr-utils';
+
+assert.deepEqual(
+  [
+    'Xenova/whisper-tiny',
+    'onnx-community/whisper-base_timestamped',
+    'Xenova/whisper-small',
+    'Xenova/whisper-medium',
+    'onnx-community/whisper-large-v3-turbo_timestamped',
+  ].map(nativeGgmlFileName),
+  [
+    'ggml-tiny-q5_1.bin',
+    'ggml-base-q5_1.bin',
+    'ggml-small-q5_1.bin',
+    'ggml-medium-q5_1.bin',
+    'ggml-large-v3-turbo-q5_0.bin',
+  ],
+  'desktop-native GGML resolution covers every supported tier',
+);
+assert.equal(nativeGgmlFileName('unknown/model'), undefined, 'unknown models stay unsupported');
 
 // Language mapping and token->chunk projection are pure; the real whisper-cli
 // invocation is exercised by the desktop smoke (native-asr-service).


### PR DESCRIPTION
## Summary

- resolve desktop-native GGML filenames from the shared ASR model catalog
- preserve the existing small and medium filename fallbacks for compatible local caches
- add executable coverage for every supported tier and unknown model IDs

## Problem

The shared catalog already downloads a GGML companion for Whisper Large v3 Turbo, but the desktop worker maintained a separate model map that did not include its model ID. As a result, a complete Large v3 Turbo download could not be selected by the native worker and the app fell back to the browser ONNX path.

This is related to #120 and specifically addresses the Large v3 Turbo desktop-native routing gap. It does not claim to fix the separate Medium ONNX load error or interrupted-download reset reported in that issue.

## Verification

- regression A/B: the old four-entry mapping fails the new Large v3 Turbo assertion; the fix passes all five tiers plus the unknown-model boundary
- npm test
- npm run lint
- npm run build
- npm run verify:desktop-inference
- npm run verify:speech-providers
- npm run verify:agent-skill

No UI behavior changed, so no screenshot is applicable. Developed with Codex assistance and independently reviewed and tested.