### PR TITLE
fix: make three verification gates run on Windows

### DIFF
--- a/scripts/verify-gate-coverage.verify.mjs
+++ b/scripts/verify-gate-coverage.verify.mjs
@@ -12,7 +12,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import yaml from 'js-yaml';
 
@@ -41,13 +41,19 @@ const referenced = new Set(
 );
 
 const isVerifyFile = new RegExp(`\\.verify\\.(?:${extensionPattern})$`);
+// package.json names files with "/", so a walked path must be posix-shaped before
+// it can be compared with one. On Windows `relative()` returns "a\b\c", which
+// matched nothing: every file on disk looked like an orphan and the check failed
+// with the entire corpus listed. Split on `sep` rather than replacing "\\" — a
+// backslash is a legal character in a POSIX filename.
+const posix = (path) => path.split(sep).join('/');
 const onDisk = [];
 const walk = (dir) => {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
     const full = join(dir, entry.name);
     if (entry.isDirectory()) walk(full);
-    else if (isVerifyFile.test(entry.name)) onDisk.push(relative(root, full));
+    else if (isVerifyFile.test(entry.name)) onDisk.push(posix(relative(root, full)));
   }
 };
 walk(root);

--- a/scripts/verify-registration.verify.mjs
+++ b/scripts/verify-registration.verify.mjs
@@ -10,6 +10,7 @@
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Verifies deliberately left out of the suite, each with the reason it cannot
@@ -18,7 +19,9 @@ import { readFileSync } from 'node:fs';
  */
 const EXCLUDED = new Map([]);
 
-const root = new URL('..', import.meta.url).pathname;
+// fileURLToPath, not .pathname: on Windows the latter yields "/D:/repo", which is
+// not a usable cwd — spawnSync died with ENOENT and this check never ran there.
+const root = fileURLToPath(new URL('..', import.meta.url));
 const tracked = execFileSync('git', ['ls-files'], { cwd: root, encoding: 'utf8' })
   .split('\n')
   .filter((file) => /\.verify\.(ts|tsx|mjs)$/.test(file));

--- a/src/gl/shader-contract.verify.ts
+++ b/src/gl/shader-contract.verify.ts
@@ -17,7 +17,14 @@ const files: Record<string, string> = {
 };
 
 for (const [name, expected] of Object.entries(files)) {
-  const source = readFileSync(fileURLToPath(new URL(name, import.meta.url)), 'utf8').trim();
+  // Normalize CRLF before hashing. These digests pin shader CONTENT, not the
+  // checkout's line endings — with git's core.autocrlf=true (the Windows
+  // default) every one of these files lands as CRLF and all nine hashes
+  // mismatched, which reads as "someone edited the shaders" rather than
+  // "this is Windows".
+  const source = readFileSync(fileURLToPath(new URL(name, import.meta.url)), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .trim();
   assert.strictEqual(createHash('sha256').update(source).digest('hex'), expected, `${name} content changed`);
 }
 


### PR DESCRIPTION
Three checks in the suite fail on a stock Windows checkout for reasons unrelated to the code they guard. Each fails in a way that reads as a real defect, which makes them expensive to triage.

All three are platform-portability fixes; none weakens what the check asserts.

## 1. `scripts/verify-registration.verify.mjs` — invalid cwd

```js
const root = new URL('..', import.meta.url).pathname;   // "/D:/repo" on Windows
```

`URL.pathname` keeps the leading slash, so `execFileSync('git', …, { cwd: root })` receives `/D:/repo` and dies with `spawnSync git ENOENT` before asserting anything. The check never ran on Windows — it did not fail loudly, it simply never executed.

Fixed with `fileURLToPath`, which is what the sibling scripts already use.

## 2. `scripts/verify-gate-coverage.verify.mjs` — separator mismatch

The walker builds paths with `relative()` (`server\plugins\x.verify.ts` on Windows) and compares them against the names in `package.json` (`server/plugins/x.verify.ts`). Nothing ever matched, so every file on disk looked unreferenced:

```
481 verify file(s) never run in `npm test`
  - server/plugins/export-runtime.verify.ts      ← actually registered
  - server/plugins/export-stage.verify.ts        ← actually registered
  …
```

Normalized with `split(sep).join('/')` rather than replacing `"\\"`, since a backslash is a legal character in a POSIX filename.

Worth noting: with the scan working, this check now reaches its later assertions and reports a pre-existing violation — `server/keystore.ts` is 502 lines against the 500-line ceiling. I have deliberately left that alone; it is your call whether to split the file or adjust the limit, and it did not belong in a portability fix.

## 3. `src/gl/shader-contract.verify.ts` — hashing line endings

The check pins nine shaders by sha256 of their bytes. With git's `core.autocrlf=true` (the Windows default) they land as CRLF and every hash mismatches:

```
AssertionError: fx/ascii-rain-blur.frag content changed
+ 'faecb2e4cee39d665e358755d788bc6874adce932a2531c7a314bcdcb3e3ccc8'
- '5b95563707c5cf9459fa904b3db9d5db55b19105158a5e73ddca3b3175672cf6'
```

That message says someone edited the shaders, which is alarming and wrong. The digests pin shader *content*, not the checkout's line endings, so normalizing CRLF before hashing reproduces the committed values exactly and keeps the check just as strict about real edits.

## Verification

On Windows (Node 24.21, `core.autocrlf=true`):

- `verify-registration` passes — all 576 tracked verify files registered
- `verify-gate-coverage` gets past the orphan scan to its later assertions
- `shader-contract` passes on all nine shaders
- `npm run lint` and `tsc -b` clean

The `fileURLToPath` and `split(sep).join('/')` changes are no-ops on POSIX, and the CRLF normalization is a no-op on any LF checkout.

Found while running the suite end to end on Windows 11. Thanks for a codebase where the gates are strict enough to be worth fixing.