### PR TITLE
fix(transcript): honor the provider override on retry_transcription

### DIFF
--- a/assets/agent/openchatcut-tool-schemas.json
+++ b/assets/agent/openchatcut-tool-schemas.json
@@ -665,7 +665,7 @@
     },
     {
       "name": "manage_transcript",
-      "description": "Correct source transcripts and manage translation variants; most actions leave word timing and clip duration unchanged. Eight actions:\n- fix: correct the source transcript. For a word, pass wordIndex or find with the incorrect source text plus text with the correction; only word.text changes. To rename or merge a speaker, pass from with an existing label such as \"A\" plus to with the new display name; passing another existing label merges them. Only word.speaker changes.\n- clear_edits: restore the clip to the raw transcript by clearing deleted words, silence caps, gap overrides, and play-order overrides (same as the Transcript panel 「还原全部」). Retimes the clip to the full transcript duration.\n- set_play_order: reorder spoken playback via playOrder word-index array (same as dragging speech blocks in the Transcript panel). Pass playOrder:null or clearPlayOrder:true to restore chronological order. Retimes the clip.\n- retry_transcription: force ASR to rerun for the clip and replace its transcript when transcription is stuck, failed, or needs refreshing.\n- translation_create: translate the full transcript to lang and create or replace a word-level translation variant sharing the source timeline.\n- translation_ensure: idempotently reuse an existing variant for lang or create it otherwise. Prefer this for ordinary translation requests.\n- translation_list: list the source transcript and all translation variants with id/lang/word count.\n- translation_read: read words from a translation variant selected by lang or targetLanguage.\nTranslation variants contain translated text only. To display a language in captions, use edit_captions language_mode.",
+      "description": "Correct source transcripts and manage translation variants; most actions leave word timing and clip duration unchanged. Eight actions:\n- fix: correct the source transcript. For a word, pass wordIndex or find with the incorrect source text plus text with the correction; only word.text changes. To rename or merge a speaker, pass from with an existing label such as \"A\" plus to with the new display name; passing another existing label merges them. Only word.speaker changes.\n- clear_edits: restore the clip to the raw transcript by clearing deleted words, silence caps, gap overrides, and play-order overrides (same as the Transcript panel 「还原全部」). Retimes the clip to the full transcript duration.\n- set_play_order: reorder spoken playback via playOrder word-index array (same as dragging speech blocks in the Transcript panel). Pass playOrder:null or clearPlayOrder:true to restore chronological order. Retimes the clip.\n- retry_transcription: force ASR to rerun for the clip and replace its transcript when transcription is stuck, failed, or needs refreshing. Accepts the same optional provider override as transcribe_track.\n- translation_create: translate the full transcript to lang and create or replace a word-level translation variant sharing the source timeline.\n- translation_ensure: idempotently reuse an existing variant for lang or create it otherwise. Prefer this for ordinary translation requests.\n- translation_list: list the source transcript and all translation variants with id/lang/word count.\n- translation_read: read words from a translation variant selected by lang or targetLanguage.\nTranslation variants contain translated text only. To display a language in captions, use edit_captions language_mode.",
       "input_schema": {
         "type": "object",
         "properties": {
@@ -690,6 +690,20 @@
           "track": {
             "type": "string",
             "description": "When itemId is omitted, locate by track alias or stable id; default A1."
+          },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "assemblyai",
+              "local",
+              "openai",
+              "mistral",
+              "deepgram",
+              "groq",
+              "elevenlabs",
+              "cartesia"
+            ],
+            "description": "retry_transcription: optional configured provider override, same values as transcribe_track. Omit to use the provider selected in Settings."
           },
           "wordIndex": {
             "type": "number",

--- a/src/agent/tools/schemas/transcript-tools.ts
+++ b/src/agent/tools/schemas/transcript-tools.ts
@@ -123,7 +123,7 @@ export const TRANSCRIPT_TOOL_SCHEMAS: AgentToolSchema[] = [
       + '- fix: correct the source transcript. For a word, pass wordIndex or find with the incorrect source text plus text with the correction; only word.text changes. To rename or merge a speaker, pass from with an existing label such as "A" plus to with the new display name; passing another existing label merges them. Only word.speaker changes.\n'
       + '- clear_edits: restore the clip to the raw transcript by clearing deleted words, silence caps, gap overrides, and play-order overrides (same as the Transcript panel 「还原全部」). Retimes the clip to the full transcript duration.\n'
       + '- set_play_order: reorder spoken playback via playOrder word-index array (same as dragging speech blocks in the Transcript panel). Pass playOrder:null or clearPlayOrder:true to restore chronological order. Retimes the clip.\n'
-      + '- retry_transcription: force ASR to rerun for the clip and replace its transcript when transcription is stuck, failed, or needs refreshing.\n'
+      + '- retry_transcription: force ASR to rerun for the clip and replace its transcript when transcription is stuck, failed, or needs refreshing. Accepts the same optional provider override as transcribe_track.\n'
       + '- translation_create: translate the full transcript to lang and create or replace a word-level translation variant sharing the source timeline.\n'
       + '- translation_ensure: idempotently reuse an existing variant for lang or create it otherwise. Prefer this for ordinary translation requests.\n'
       + '- translation_list: list the source transcript and all translation variants with id/lang/word count.\n'
@@ -142,6 +142,11 @@ export const TRANSCRIPT_TOOL_SCHEMAS: AgentToolSchema[] = [
         },
         itemId: { type: 'string', description: 'Target clip item id or unique prefix; omit to use the first transcribed audio/video clip on the track.' },
         track: { type: 'string', description: 'When itemId is omitted, locate by track alias or stable id; default A1.' },
+        provider: {
+          type: 'string',
+          enum: ['assemblyai', 'local', 'openai', 'mistral', 'deepgram', 'groq', 'elevenlabs', 'cartesia'],
+          description: 'retry_transcription: optional configured provider override, same values as transcribe_track. Omit to use the provider selected in Settings.',
+        },
         wordIndex: { type: 'number', description: 'fix word: index of the word to correct; mutually exclusive with find.' },
         find: { type: 'string', description: 'fix word: incorrect source text that must match exactly one word; mutually exclusive with wordIndex.' },
         text: { type: 'string', description: 'fix word: corrected text.' },

--- a/src/agent/tools/transcript-tools.ts
+++ b/src/agent/tools/transcript-tools.ts
@@ -120,8 +120,24 @@ async function manageTranscript(args: Args, ctx: AgentContext, track: TrackId, a
   // retry_transcription: force a fresh ASR run (the only action that doesn't need an existing transcript).
   if (action === 'retry_transcription') {
     if (!it.src) return { error: `item ${it.id} has no media to transcribe` };
+    // Honor the same provider override transcribe_track accepts. Without it a
+    // retry always fell back to the default provider, so on a setup configured
+    // for (say) Groq the only way to redo a transcript failed with
+    // "AssemblyAI API key is not configured" — even though the initial
+    // transcribe_track had just succeeded.
+    const provider = args.provider === undefined
+      ? undefined
+      : isTranscriptionProviderId(args.provider) ? args.provider : undefined;
+    if (args.provider !== undefined && provider === undefined) {
+      return { error: `unsupported transcription provider: ${String(args.provider)}` };
+    }
     try {
-      const r = await transcribePath(it.src);
+      const r = await transcribePath(
+        it.src,
+        (note) => { if (note) ctx.onToolProgress?.(note); },
+        {},
+        provider,
+      );
       ctx.commands.setItemTranscript(it.id, r.words);
       return { ok: true, action, itemId: it.id, words: r.words.length, text: r.text.slice(0, 200), retried: true };
     } catch (e) {


### PR DESCRIPTION
`manage_transcript action=retry_transcription` is the only way to force a fresh ASR pass over a clip that already carries a transcript — `transcribe_track` skips those with `already-transcribed`. The retry path silently drops the provider, so on any install not configured for the default provider it is impossible to redo a transcript at all.

## The asymmetry

`transcribe_track` resolves an optional provider and forwards it:

```ts
// src/agent/tools/transcript-tools.ts:279
const r = await transcribePath(it.src!, (note) => { … }, {}, provider);
```

`retry_transcription` calls the same function with neither the provider nor the progress callback:

```ts
// src/agent/tools/transcript-tools.ts:124
const r = await transcribePath(it.src);
```

`transcribePath` then falls back to its default parameter, and `manage_transcript` exposes no `provider` field at all, so a caller has no way to influence it.

## How it surfaces

On a machine configured for Groq and with no AssemblyAI key, `transcribe_track` succeeds and the retry fails seconds later:

```json
{"ok":true,"track":"V1","provider":"groq","clips":1,"results":[{"words":90, …}]}

{"error":"transcription failed: AssemblyAI server upload failed:
          HTTP 503: {\"error\":\"AssemblyAI API key is not configured\"}"}
```

The practical consequence is worse than a confusing message. A transcript produced with the wrong language setting — easy to hit, since the browser default is `zh` — becomes unrecoverable through the tool surface: `transcribe_track` refuses the clip, and the retry cannot reach a configured provider. The only workaround is deleting and re-adding the clip, which throws away its timeline edits.

## The change

The retry now resolves `provider` exactly as `transcribe_track` does, rejects an unsupported value with the same message, and forwards the progress callback so long runs report through `onToolProgress`. `provider` is added to the `manage_transcript` schema with the same enum and wording.

Omitting it keeps the previous behavior, so nothing existing changes.

```ts
const provider = args.provider === undefined
  ? undefined
  : isTranscriptionProviderId(args.provider) ? args.provider : undefined;
if (args.provider !== undefined && provider === undefined) {
  return { error: `unsupported transcription provider: ${String(args.provider)}` };
}
```

`assets/agent/openchatcut-tool-schemas.json` is regenerated via `npm run generate:server-tool-catalog`.

## Verification

- `npx tsx src/agent/tools/transcript-tools.verify.ts` passes
- `npm run verify:server-tool-catalog` reports the catalog current
- `npm run lint` and `tsc -b` clean
- Confirmed against a live editor over the external MCP transport: `retry_transcription` with `provider: "groq"` now returns `{"ok":true, "words":70, "retried":true}` on a clip that previously could not be re-transcribed at all

Found while driving the MCP surface end to end for an agent-orchestrated editing workflow. Happy to adjust the schema wording if you would rather phrase the override differently.